### PR TITLE
fix: Conserta path dos templates de e-mail

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,7 +41,9 @@ import { SchedulesModule } from './schedules/schedules.module';
         },
       },
       template: {
-        dir: join(__dirname.replace('src', 'email') + '/templates'),
+        dir: join(
+          __dirname.slice(0, __dirname.length - 4) + '/email/templates',
+        ),
         adapter: new HandlebarsAdapter(),
         options: {
           strict: true,


### PR DESCRIPTION
# Descrição

Conserta o path dos templates de e-mail para apontar à pasta certa: `/dist/email/templates`.

