### PR TITLE
fix: Filtra monitores por status e pagina no banco

### DIFF
--- a/src/common/dto/query-pagination.dto.ts
+++ b/src/common/dto/query-pagination.dto.ts
@@ -32,3 +32,25 @@ export class QueryPaginationDto {
   })
   search: string;
 }
+
+class PaginationMeta {
+  @ApiProperty({ type: Number })
+  page: number;
+
+  @ApiProperty({ type: Number })
+  pageSize: number;
+
+  @ApiProperty({ type: Number })
+  totalItems: number;
+
+  @ApiProperty({ type: Number })
+  totalPages: number;
+}
+
+export class PaginationResponse<T> {
+  @ApiProperty()
+  data: T[];
+
+  @ApiProperty({ type: PaginationMeta })
+  meta: PaginationMeta;
+}

--- a/src/monitor/commands/list-monitors.command.ts
+++ b/src/monitor/commands/list-monitors.command.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@nestjs/common';
+import { Role } from 'src/auth/enums/role.enum';
+import { PrismaService } from 'src/database/prisma.service';
+import {
+  ListMonitorsQueryParams,
+  ListMonitorsResponse,
+} from '../dto/list-monitors.request.dto';
+
+@Injectable()
+export class ListMonitorsCommand {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async execute(
+    userId: number,
+    userRole: Role,
+    query: ListMonitorsQueryParams,
+  ): Promise<ListMonitorsResponse> {
+    const take = query.pageSize || 10;
+    const skip = query.page && query.page > 0 ? (query.page - 1) * take : 0;
+    const where = {
+      responsible_professor_id:
+        userRole === Role.Professor ? userId : undefined,
+      id_status: query.status,
+      OR: [
+        {
+          student: {
+            user: {
+              name: {
+                contains: query.name,
+              },
+            },
+          },
+        },
+        {
+          responsible_professor: {
+            user: {
+              name: {
+                contains: query.name,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const monitors = await this.prismaService.monitor.findMany({
+      where,
+      include: {
+        student: {
+          select: {
+            user: { select: { name: true } },
+            course: { select: { name: true, code: true } },
+          },
+        },
+        subject: true,
+        responsible_professor: {
+          select: { user: { select: { name: true } } },
+        },
+        status: { select: { status: true } },
+      },
+      take,
+      skip,
+    });
+    const totalItems = await this.prismaService.monitor.count({ where });
+
+    return {
+      data: monitors,
+      meta: {
+        page: query.page || 1,
+        pageSize: take,
+        totalItems,
+        totalPages: Math.ceil(totalItems / take),
+      },
+    };
+  }
+}

--- a/src/monitor/dto/list-monitors.request.dto.ts
+++ b/src/monitor/dto/list-monitors.request.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Monitor } from '@prisma/client';
+import { Type } from 'class-transformer';
+import { IsOptional, IsString } from 'class-validator';
+import { PaginationResponse } from 'src/common/dto/query-pagination.dto';
+import { MonitorStatus } from '../utils/monitor.enum';
+
+export class ListMonitorsQueryParams {
+  @ApiProperty({
+    required: false,
+    description: 'Número da página',
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  page?: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'Quantidade de registros por página',
+    default: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  pageSize?: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'Busca pelo nome do monitor ou do professor responsável',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Busca pelo status da monitoria',
+    type: MonitorStatus,
+  })
+  @Type(() => Number)
+  @IsOptional()
+  status?: MonitorStatus;
+}
+
+export class ListMonitorsResponse extends PaginationResponse<Monitor> {}

--- a/src/monitor/monitor.module.ts
+++ b/src/monitor/monitor.module.ts
@@ -11,6 +11,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from 'src/auth/strategies/jwt.strategy';
 import { StudentModule } from 'src/student/student.module';
 import { UserModule } from 'src/user/user.module';
+import { ListMonitorsCommand } from './commands/list-monitors.command';
 
 @Module({
   controllers: [MonitorController],
@@ -23,6 +24,7 @@ import { UserModule } from 'src/user/user.module';
     CourseService,
     TeacherService,
     JwtStrategy,
+    ListMonitorsCommand,
   ],
 })
 export class MonitorModule {}

--- a/src/monitor/utils/monitor.enum.ts
+++ b/src/monitor/utils/monitor.enum.ts
@@ -1,0 +1,7 @@
+export enum MonitorStatus {
+  PENDING = 1,
+  APPROVED = 2,
+  AVAILABLE = 3,
+  DONE = 4,
+  REJECTED = 5,
+}


### PR DESCRIPTION
# Descrição

- Recebe o campo status como parâmetro na rota `GET /monitor/all`.
- Pagina resultado na rota direto no banco.
- Extrai método de listar monitorias para usar o padrão command.

# Setup

- [ ] Altere o arquivo `.env` para apontar ao banco de staging.
- [ ] `make build up`

# Cenários

## 1. Listar monitores como professor

- [x] Faça login com a conta de professor `juan.professor@icomp.ufam.edu.br` | `12345678`.
- [x] Faça uma requisição para a rota `GET /monitor/all` sem passar paramentros.
- [x] Verifique se no resultado foram retornados apenas os monitores do professor Juan Colonna
- [x] Faça uma requisição para a rota `GET /monitor/all` passado `status` com o valor 1
- [x] Verifique se no resultado foram retornados apenas os monitores com status pendente do professor Juan Colonna

## 2. Listar monitores como coordenador

- [x] Faça login com a conta de coordenador `coordenador@icomp.ufam.edu.br` | `12345678`.
- [x] Faça uma requisição para a rota `GET /monitor/all` sem passar paramentros.
- [x] Verifique se no resultado foram retornados monitores de diferentes professores.
- [x] Faça uma requisição para a rota `GET /monitor/all` passado `status` com o valor 1
- [x] Verifique se no resultado foram retornados apenas os monitores com status pendente

