### PR TITLE
fix: Verifica disponibilidade de monitor ao agendar

### DIFF
--- a/src/schedules/domain/schedule.ts
+++ b/src/schedules/domain/schedule.ts
@@ -27,14 +27,14 @@ export class Schedule {
   status: ScheduleStatus;
 
   @ApiProperty({ type: Monitor })
-  monitor: Monitor;
+  monitor?: Monitor;
 
   @ApiProperty({ type: Student })
-  student: Student;
+  student?: Student;
 
   @ApiProperty({ type: User })
-  responsibleProfessor: User;
+  responsibleProfessor?: User;
 
   @ApiProperty({ type: Subject })
-  subject: Subject;
+  subject?: Subject;
 }

--- a/src/schedules/utils/schedule.factory.ts
+++ b/src/schedules/utils/schedule.factory.ts
@@ -2,37 +2,54 @@ import { Schedule } from '../domain/schedule';
 
 export class ScheduleFactory {
   static createFromPrisma(prismaSchedule): Schedule {
-    return {
+    const schedule: Schedule = {
       id: prismaSchedule.id,
       startDate: prismaSchedule.start,
       endDate: prismaSchedule.end,
       status: prismaSchedule.id_status,
-      monitor: {
+    };
+
+    if (!!prismaSchedule.monitor) {
+      schedule.monitor = {
         id: prismaSchedule.monitor.id,
         userId: prismaSchedule.monitor.student.user.id,
         enrollment: prismaSchedule.monitor.student.enrollment,
         name: prismaSchedule.monitor.student.user.name,
         email: prismaSchedule.monitor.student.user.email,
-      },
-      student: {
+      };
+
+      if (!!prismaSchedule.monitor.responsible_professor) {
+        schedule.responsibleProfessor = {
+          id: prismaSchedule.monitor.responsible_professor.user.id,
+          name: prismaSchedule.monitor.responsible_professor.user.name,
+          email: prismaSchedule.monitor.responsible_professor.user.email,
+        };
+      }
+
+      if (!!prismaSchedule.monitor.subject) {
+        schedule.subject = {
+          id: prismaSchedule.monitor.subject.id,
+          name: prismaSchedule.monitor.subject.name,
+        };
+
+        if (!!prismaSchedule.monitor.subject.course) {
+          schedule.subject.course = {
+            id: prismaSchedule.monitor.subject.course.id,
+            name: prismaSchedule.monitor.subject.course.name,
+          };
+        }
+      }
+    }
+
+    if (!!prismaSchedule.student) {
+      schedule.student = {
         id: prismaSchedule.student.user.id,
         enrollment: prismaSchedule.student.enrollment,
         name: prismaSchedule.student.user.name,
         email: prismaSchedule.student.user.email,
-      },
-      responsibleProfessor: {
-        id: prismaSchedule.monitor.responsible_professor.user.id,
-        name: prismaSchedule.monitor.responsible_professor.user.name,
-        email: prismaSchedule.monitor.responsible_professor.user.email,
-      },
-      subject: {
-        id: prismaSchedule.monitor.subject.id,
-        name: prismaSchedule.monitor.subject.name,
-        course: {
-          id: prismaSchedule.monitor.subject.course.id,
-          name: prismaSchedule.monitor.subject.course.name,
-        },
-      },
-    };
+      };
+    }
+
+    return schedule;
   }
 }

--- a/src/student/commands/schedule-monitoring.command.ts
+++ b/src/student/commands/schedule-monitoring.command.ts
@@ -1,113 +1,136 @@
-import {
-  BadRequestException,
-  ForbiddenException,
-  Injectable,
-  PreconditionFailedException,
-} from '@nestjs/common';
-import * as moment from 'moment';
+import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
+import { MonitorStatus } from 'src/monitor/utils/monitor.enum';
+import { ScheduleStatus } from 'src/schedules/utils/schedules.enum';
 import { ScheduleMonitoringDto } from '../dto/schedule-monitoring.dto';
-import { FindOneByIdCommand } from './find-one-by-id.command';
-import { GetMonitorAvailabilityCommand } from './get-monitor-availability.command';
+import { ScheduleFactory } from '../../schedules/utils/schedule.factory';
+import {
+  InvalidDateException,
+  MonitorNotFoundException,
+  MonitorStatusNotAvailableException,
+  MonitorTimeAlreadyScheduledException,
+  NotAnAvailableTimeException,
+  SameStudentException,
+} from '../utils/exceptions';
+import { Schedule } from 'src/schedules/domain/schedule';
 
 @Injectable()
 export class ScheduleMonitoringCommand {
-  constructor(
-    private prisma: PrismaService,
-    private readonly findOneByIdCommand: FindOneByIdCommand,
-    private readonly getMonitorAvailabilityCommand: GetMonitorAvailabilityCommand,
-  ) {}
+  constructor(private prisma: PrismaService) {}
 
-  /**
-   * TODO: Resolve Promise<any> return type
-   */
   async execute(
-    student_id: number,
-    monitor_id: number,
+    userId: number,
+    monitorId: number,
     data: ScheduleMonitoringDto,
-  ): Promise<any> {
-    const user = await this.findOneByIdCommand.execute(student_id);
-    if (!user) throw new ForbiddenException('Aluno não encontrado.');
-
-    const monitor = await this.prisma.monitor.findFirst({
-      where: { id: monitor_id },
-    });
-    if (!monitor) throw new ForbiddenException('Monitor não encontrado.');
+  ): Promise<Schedule> {
+    const { start, end } = data;
+    const now = new Date();
+    const AMT_OFFSET = -4;
+    now.setHours(now.getHours() + AMT_OFFSET);
 
     if (
-      monitor.id_status == 5 ||
-      monitor.id_status == 1 ||
-      monitor.id_status == 4
+      start <= now ||
+      start >= end ||
+      start.toLocaleDateString() !== end.toLocaleDateString()
     )
-      throw new PreconditionFailedException('Monitor não disponível.');
+      throw new InvalidDateException();
 
-    if (monitor.id_status !== 3)
-      throw new PreconditionFailedException('Monitor não disponível');
-
-    if (user.user_id === monitor.student_id)
-      throw new PreconditionFailedException(
-        'Não foi possível agendar a monitoria, aluno e monitor são o mesmo usuário.',
-      );
-
-    data.start = moment(data.start).format('YYYY-MM-DDTHH:mm:ssZ');
-    data.end = moment(data.end).format('YYYY-MM-DDTHH:mm:ssZ');
-
-    if (!moment(data.start).isBefore(moment(data.end)))
-      throw new BadRequestException(
-        'Data de início deve ser anterior a data de término',
-      );
-
-    const start_weekday = moment(data.start).day();
-    const start_minute = moment(data.start).minute();
-    const start_hour = moment(data.start).hour();
-    const start_time = `${start_hour < 10 ? '0' + start_hour : start_hour}:${
-      start_minute < 10 ? '0' + start_minute : start_minute
-    }`;
-
-    const end_weekday = moment(data.end).day();
-    const end_minute = moment(data.end).minute();
-    const end_hour = moment(data.end).hour();
-    const end_time = `${end_hour < 10 ? '0' + end_hour : end_hour}:${
-      end_minute < 10 ? '0' + end_minute : end_minute
-    }`;
-
-    const monitorAvailability = await this.getMonitorAvailabilityCommand.execute(monitor.id);
-
-    const sameDay = monitorAvailability.filter(
-      (item) =>
-        item.week_day === start_weekday && item.week_day === end_weekday,
-    );
-
-    if (sameDay.length === 0)
-      throw new PreconditionFailedException(
-        'Monitor não disponível nas datas selecionadas.',
-      );
-
-    sameDay.forEach((item) => {
-      if (
-        moment(start_time, 'HH:mm').isBefore(moment(item.start, 'HH:mm')) ||
-        moment(start_time, 'HH:mm').isAfter(moment(item.end, 'HH:mm'))
-      )
-        throw new PreconditionFailedException(
-          'Monitor não disponível no horário selecionado',
-        );
-      if (
-        moment(end_time, 'HH:mm').isBefore(moment(item.start, 'HH:mm')) ||
-        moment(end_time, 'HH:mm').isAfter(moment(item.end, 'HH:mm'))
-      )
-        throw new PreconditionFailedException(
-          'Monitor não disponível no horário selecionado',
-        );
+    const monitor = await this.prisma.monitor.findFirst({
+      where: { id: monitorId },
     });
+    if (!monitor) throw new MonitorNotFoundException();
 
-    await this.prisma.scheduleMonitoring.create({
+    if (monitor.id_status !== MonitorStatus.AVAILABLE)
+      throw new MonitorStatusNotAvailableException();
+
+    if (monitor.student_id === userId) throw new SameStudentException();
+
+    await this.checkAvailability(monitorId, start, end);
+
+    await this.checkConfirmedSchedules(monitorId, start, end);
+
+    const newSchedule = await this.prisma.scheduleMonitoring.create({
       data: {
-        student_id: student_id,
-        monitor_id: monitor.id,
-        start: data.start,
-        end: data.end,
+        student_id: userId,
+        monitor_id: monitorId,
+        start: start,
+        end: end,
       },
     });
-    return { message: 'Monitoria agendada com sucesso' };
+
+    return ScheduleFactory.createFromPrisma(newSchedule);
+  }
+
+  private async checkAvailability(monitorId: number, start: Date, end: Date) {
+    const availability = await this.prisma.availableTimes.findFirst({
+      where: {
+        monitor_id: monitorId,
+        week_day: start.getDay(),
+      },
+    });
+    if (!availability) throw new NotAnAvailableTimeException();
+
+    const startAvailability = new Date(start);
+    startAvailability.setHours(
+      Number(availability.start.split(':')[0]),
+      Number(availability.start.split(':')[1]),
+      0,
+    );
+
+    const endAvailability = new Date(end);
+    endAvailability.setHours(
+      Number(availability.end.split(':')[0]),
+      Number(availability.end.split(':')[1]),
+      0,
+    );
+
+    if (
+      start < startAvailability ||
+      start >= endAvailability ||
+      end <= startAvailability ||
+      end > endAvailability
+    )
+      throw new NotAnAvailableTimeException();
+  }
+
+  private async checkConfirmedSchedules(
+    monitorId: number,
+    start: Date,
+    end: Date,
+  ) {
+    const conflitingSchedule = await this.prisma.scheduleMonitoring.findFirst({
+      where: {
+        monitor_id: monitorId,
+        id_status: ScheduleStatus.CONFIRMED,
+        OR: [
+          {
+            start: {
+              lte: start,
+            },
+            end: {
+              gt: start,
+            },
+          },
+          {
+            start: {
+              lt: end,
+            },
+            end: {
+              gte: end,
+            },
+          },
+          {
+            start: {
+              gte: start,
+            },
+            end: {
+              lte: end,
+            },
+          },
+        ],
+      },
+    });
+
+    if (conflitingSchedule) throw new MonitorTimeAlreadyScheduledException();
   }
 }

--- a/src/student/dto/schedule-monitoring.dto.ts
+++ b/src/student/dto/schedule-monitoring.dto.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 
 export class ScheduleMonitoringDto {
   @ApiProperty({
     example: '2023-01-20 10:00:00',
   })
-  start: string;
+  @Transform(({ value }) => value && new Date(value))
+  start: Date;
 
   @ApiProperty({
     example: '2023-01-20 11:00:00',
   })
-  end: string;
+  @Transform(({ value }) => value && new Date(value))
+  end: Date;
 }

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -1,9 +1,12 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
+  NotFoundException,
   Param,
   Post,
+  PreconditionFailedException,
   Query,
   Req,
   UseGuards,
@@ -12,10 +15,19 @@ import { JwtService } from '@nestjs/jwt';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { JWTUser } from 'src/auth/interfaces/jwt-user.interface';
 import { ListStudentSchedulesCommand } from './commands/list-student-schedules.command';
 import { ScheduleMonitoringCommand } from './commands/schedule-monitoring.command';
 import { ScheduleMonitoringDto } from './dto/schedule-monitoring.dto';
 import { SchedulesDto } from './dto/schedules.dto';
+import {
+  InvalidDateException,
+  MonitorNotFoundException,
+  MonitorStatusNotAvailableException,
+  MonitorTimeAlreadyScheduledException,
+  NotAnAvailableTimeException,
+  SameStudentException,
+} from './utils/exceptions';
 
 @ApiTags('Students')
 @Controller('student')
@@ -23,7 +35,7 @@ export class StudentController {
   constructor(
     private readonly scheduleMonitoringCommand: ScheduleMonitoringCommand,
     private readonly listStudentSchedulesCommand: ListStudentSchedulesCommand,
-    private readonly jwtService: JwtService
+    private readonly jwtService: JwtService,
   ) {}
 
   @UseGuards(JwtAuthGuard)
@@ -35,9 +47,37 @@ export class StudentController {
     @Body() body: ScheduleMonitoringDto,
   ) {
     const token = req.headers.authorization.toString().replace('Bearer ', '');
-    const payload = this.jwtService.decode(token);
-    const student_id = payload.sub as number;
-    return this.scheduleMonitoringCommand.execute(student_id, monitor_id, body);
+    const user = this.jwtService.decode(token) as JWTUser;
+
+    try {
+      return await this.scheduleMonitoringCommand.execute(
+        user.sub,
+        monitor_id,
+        body,
+      );
+    } catch (error) {
+      if (error instanceof MonitorNotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+
+      if (
+        error instanceof InvalidDateException ||
+        error instanceof SameStudentException
+      ) {
+        throw new BadRequestException(error.message);
+      }
+
+      if (
+        error instanceof MonitorStatusNotAvailableException ||
+        error instanceof MonitorStatusNotAvailableException ||
+        error instanceof NotAnAvailableTimeException ||
+        error instanceof MonitorTimeAlreadyScheduledException
+      ) {
+        throw new PreconditionFailedException(error.message);
+      }
+
+      throw error;
+    }
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/student/utils/exceptions.ts
+++ b/src/student/utils/exceptions.ts
@@ -1,0 +1,41 @@
+export class MonitorNotFoundException extends Error {
+  constructor() {
+    super();
+    this.message = `Monitor não encontrado`;
+  }
+}
+
+export class MonitorStatusNotAvailableException extends Error {
+  constructor() {
+    super();
+    this.message = `Monitor não disponível para agendamentos`;
+  }
+}
+
+export class SameStudentException extends Error {
+  constructor() {
+    super();
+    this.message = `Monitor e usuário logado são a mesma pessoa`;
+  }
+}
+
+export class InvalidDateException extends Error {
+  constructor() {
+    super();
+    this.message = `Data de início e/ou fim inválida(s)`;
+  }
+}
+
+export class NotAnAvailableTimeException extends Error {
+  constructor() {
+    super();
+    this.message = `A data do agendamento não está dentro dos horários disponíveis do monitor`;
+  }
+}
+
+export class MonitorTimeAlreadyScheduledException extends Error {
+  constructor() {
+    super();
+    this.message = `Monitor já possui um agendamento confirmado no horário solicitado`;
+  }
+}

--- a/src/subject/domain/subject.ts
+++ b/src/subject/domain/subject.ts
@@ -13,5 +13,5 @@ export class Subject {
   code?: string;
 
   @ApiProperty({ type: Course })
-  course: Course;
+  course?: Course;
 }


### PR DESCRIPTION
# Descrição

Ao criar um agendamento não estão sendo feitas validações corretas encima dos horários disponíveis do monitor e dos agendamentos confirmados que ele já possui.

# Setup

- [x] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [x] Suba a API com `make build up`
- [x] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

Considerando que o horários disponível do monitor 11 é todos os dias das 09:00 até as 14:00 e que o único agendamento confirmado dele começa em `2023-03-26 09:00:00` e termina em `2023-03-26 10:00:00`, faça requisições para a rota `POST /student/{monitor_id}/schedule` variando as datas de início e fim para validar se:
- [x] Só é possível agendar dentro dos horários disponíveis do monitor
- [x] Só é possível agendar se o horário não conflitar com um agendamento confirmado do monitor.

