### PR TITLE
fix: Checa agendamentos do aluno ao agendar

### DIFF
--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -27,6 +27,7 @@ import {
   MonitorTimeAlreadyScheduledException,
   NotAnAvailableTimeException,
   SameStudentException,
+  StudentTimeAlreadyScheduledException,
 } from './utils/exceptions';
 
 @ApiTags('Students')
@@ -71,7 +72,8 @@ export class StudentController {
         error instanceof MonitorStatusNotAvailableException ||
         error instanceof MonitorStatusNotAvailableException ||
         error instanceof NotAnAvailableTimeException ||
-        error instanceof MonitorTimeAlreadyScheduledException
+        error instanceof MonitorTimeAlreadyScheduledException ||
+        error instanceof StudentTimeAlreadyScheduledException
       ) {
         throw new PreconditionFailedException(error.message);
       }

--- a/src/student/utils/exceptions.ts
+++ b/src/student/utils/exceptions.ts
@@ -39,3 +39,10 @@ export class MonitorTimeAlreadyScheduledException extends Error {
     this.message = `Monitor já possui um agendamento confirmado no horário solicitado`;
   }
 }
+
+export class StudentTimeAlreadyScheduledException extends Error {
+  constructor(status: string) {
+    super();
+    this.message = `Aluno já possui um agendamento com status '${status}' no horário solicitado`;
+  }
+}


### PR DESCRIPTION
# Descrição

Ao criar um agendamento não estão sendo feitas validações corretas encima dos horários disponíveis do aluno e dos agendamentos confirmados ou pendentes que ele já possui.

# Setup

- [x] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [x] Suba a API com `make up`
- [x] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

- [x] Faça uma requisição para a rota `POST /student/{monitor_id}/schedule` passando `monitor_id` como 8 e data de início e fim válidas.
- [x] Tente fazer a mesma requisição e verifique se o erro a seguir foi retornado:
   ```json
  {
    "statusCode": 412,
    "message": "Aluno já possui um agendamento com status 'Aguardando aprovação do monitor' no horário solicitado",
    "error": "Precondition Failed"
  }
  ```