### PR TITLE
fix: Possibilita reassinalar professor se a matéria já foi finalizada.

### DIFF
--- a/src/teacher/teacher.service.ts
+++ b/src/teacher/teacher.service.ts
@@ -5,6 +5,7 @@ import { pagination } from 'src/common/pagination';
 import { PrismaService } from 'src/database/prisma.service';
 import { SubjectService } from 'src/subject/subject.service';
 import { TeacherAssingDto } from './dto/teacher-assing.dto';
+import { SubjectResponsabilityStatus } from 'src/subject/utils/subject.enum';
 
 @Injectable()
 export class TeacherService {
@@ -57,6 +58,7 @@ export class TeacherService {
           where: {
             subject_id: body.subject_id,
             professor_id: professor_id,
+            id_status: { not: SubjectResponsabilityStatus.FINISHED }
           },
         });
       if (subject_responsability)


### PR DESCRIPTION
Antes, não era possível assinalar um professor a uma matéria se esse mesmo registro já estivesse no banco. Com o novo status de responsabilidade finalizada, agora é possível reassinalar um professor a uma matéria que ele já tenha ministrado anteriormente, considerando que esta responsabilidade já esteja com status 3 (Finalizada).