### PR TITLE
feat: Add schedule description

### DIFF
--- a/prisma/migrations/20230505235325_add_schedule_description/migration.sql
+++ b/prisma/migrations/20230505235325_add_schedule_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `schedule_monitoring` ADD COLUMN `description` VARCHAR(500) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -180,6 +180,7 @@ model ScheduleMonitoring {
   id         Int                      @id @default(autoincrement())
   start      DateTime
   end        DateTime
+  description String?                 @db.VarChar(500)   
   id_status  Int                      @default(1)
   status     StatusScheduleMonitoring @relation(fields: [id_status], references: [id])
   student_id Int

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -86,7 +86,10 @@ export class EmailService {
       subject: subject,
       text: subject,
       template: `${template}.hbs`,
-      context,
+      context: {
+        ...context,
+        front_end_base_url: process.env.FRONT_END_BASE_URL,
+      },
     });
   }
 

--- a/src/schedules/domain/schedule.ts
+++ b/src/schedules/domain/schedule.ts
@@ -26,6 +26,9 @@ export class Schedule {
   @ApiProperty({ type: ScheduleStatus })
   status: ScheduleStatus;
 
+  @ApiProperty({ type: String })
+  description?: string;
+
   @ApiProperty({ type: Monitor })
   monitor?: Monitor;
 

--- a/src/schedules/utils/schedule.factory.ts
+++ b/src/schedules/utils/schedule.factory.ts
@@ -7,6 +7,7 @@ export class ScheduleFactory {
       startDate: prismaSchedule.start,
       endDate: prismaSchedule.end,
       status: prismaSchedule.id_status,
+      description: prismaSchedule.description,
     };
 
     if (!!prismaSchedule.monitor) {

--- a/src/schedules/utils/select-schedule.prisma-sql.ts
+++ b/src/schedules/utils/select-schedule.prisma-sql.ts
@@ -22,6 +22,7 @@ const scheduleSelectPrismaSQL = {
   id_status: true,
   start: true,
   end: true,
+  description: true,
   ...studentSelect,
   monitor: {
     select: {

--- a/src/student/commands/schedule-monitoring.command.ts
+++ b/src/student/commands/schedule-monitoring.command.ts
@@ -28,7 +28,7 @@ export class ScheduleMonitoringCommand {
     monitorId: number,
     data: ScheduleMonitoringDto,
   ): Promise<Schedule> {
-    const { start, end } = data;
+    const { start, end, description } = data;
     const now = new Date();
     const AMT_OFFSET = -4;
     now.setHours(now.getHours() + AMT_OFFSET);
@@ -61,8 +61,9 @@ export class ScheduleMonitoringCommand {
       data: {
         student_id: userId,
         monitor_id: monitorId,
-        start: start,
-        end: end,
+        start,
+        end,
+        description,
       },
     });
 

--- a/src/student/dto/schedule-monitoring.dto.ts
+++ b/src/student/dto/schedule-monitoring.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class ScheduleMonitoringDto {
   @ApiProperty({
@@ -13,4 +14,10 @@ export class ScheduleMonitoringDto {
   })
   @Transform(({ value }) => value && new Date(value))
   end: Date;
+
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  description?: string;
 }


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Receber campo description na rota de agendamento](https://computero.atlassian.net/jira/software/projects/DS/boards/8?selectedIssue=DS-116)


<!-- O que este pull request faz? -->

- Adiciona o campo descrição na tabela ScheduleMonitoring;
- Altera a rota /student/{monitor_id}/schedule para receber o campo description; (O campo pode ser opcional);
- Tratamento de erro caso o campo seja diferente de string ou que exceda o tamanho 500;
- Altera a rota /schedules para receber o campo descrição;

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de dev
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`  
- [ ] Para testar o /Schedule  Faça login com a conta `leandro.professor@icomp.ufam.edu.br` | `12345678` 
- [ ] Insira ou utilize um monitor com Status AVALIABLE: 
          (insert into student (user_id, description, enrollment, course_id, contact_email)
          values
              (6, '', '11111111', '1', 'marcos.aluno@icomp.ufam.edu.br')); 
          (insert into monitor (id_status, responsible_professor_id, student_id, subject_id)
          values
              (1, 1, 6, 3));
# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**
- [ ] Acessar a rota /student/{monitor_id}/schedule 
- [ ] Criar uma nova Schedule sem o campo description
- [ ] Verificar que a Schedule foi cadastrada.
 

## 2. Cenário B**
- [ ] Acessar a rota /student/{monitor_id}/schedule 
- [ ] Criar uma nova Schedule o campo description sendo string com tamanho < 500
- [ ] Verificar que a Schedule foi cadastrada.

## 3. Cenário C**
- [ ] Acessar a rota /student/{monitor_id}/schedule 
- [ ] Criar uma nova Schedule o campo description sendo string com tamanho > 500
- [ ] Verificar se foi retornado erro.

## 4. Cenário D**
- [ ] Acessar a rota /student/{monitor_id}/schedule 
- [ ] Criar uma nova Schedule o campo description não sendo uma string
- [ ] Verificar se foi retornado erro.

## 5. Cenário E**
- [ ] Acessar a rota /schedules
- [ ] Verificar se foi retornado as schedules com o campo description.
