### PR TITLE
fix: Não roda husky quando instalar com ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY package*.json ./
 RUN apt-get update && apt-get install -y openssl
 
 FROM base as production
-RUN npm ci --production
+RUN npm ci --omit=dev
 COPY . ./
 RUN npx prisma generate
 RUN npm run build
@@ -13,7 +13,7 @@ EXPOSE 3003
 
 
 FROM base as staging
-RUN npm ci --production
+RUN npm ci --omit=dev
 COPY . ./
 RUN npx prisma generate
 RUN npm run build

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "lint:commit": "npx commitlint --edit  && echo \"> No errors found in commit messages.\"",
-    "prepare": "husky install"
+    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"


### PR DESCRIPTION
# Descrição

O deploy em stg não tá funcionando porque ao buildar a imagem dá erro porque o husky não é instalado. 

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
  - O husky só é instalado em dev, aí quando vai fazer deploy ele não é instalado e dá erro porque o npm tenta rodar ele.
- O que foi feito para corrigi-lo?
  - Verifica se ao rodar husky vai dar erro de módulo não encontrado, pois se der, ignora.
