### PR TITLE
feat: Cria rota para resetar a senha

### DIFF
--- a/src/user/commands/reset-password.command.ts
+++ b/src/user/commands/reset-password.command.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from 'src/database/prisma.service';
+import { hashPassword } from 'src/utils/bcrypt';
+import { Validations } from 'src/utils/validations';
+import { DecodedTokenPayload } from '../utils/decoded-token';
+import {
+  ExpiredCodeException,
+  InvalidCodeException,
+  InvalidPasswordException,
+  InvalidTokenException,
+  UsedCodeException,
+} from '../utils/exceptions';
+
+@Injectable()
+export class ResetPasswordCommand {
+  constructor(private prisma: PrismaService, private jwtService: JwtService) {}
+
+  async execute(newPassword: string, token: string): Promise<void> {
+    if (!Validations.validatePassword(newPassword))
+      throw new InvalidPasswordException();
+
+    let decodedTokenPayload: DecodedTokenPayload;
+
+    try {
+      decodedTokenPayload = this.jwtService.verify(token, {
+        secret: process.env.SECRET_KEY,
+      });
+    } catch (error) {
+      throw new InvalidTokenException();
+    }
+
+    const mostRecentCode = await this.prisma.verification_Code.findFirst({
+      where: { code: decodedTokenPayload.code },
+    });
+
+    if (!mostRecentCode) throw new InvalidCodeException();
+
+    if (mostRecentCode.is_verified) throw new UsedCodeException();
+
+    if (new Date() > decodedTokenPayload.expiresAt)
+      throw new ExpiredCodeException();
+
+    await this.prisma.verification_Code.update({
+      where: { code: decodedTokenPayload.code },
+      data: { is_verified: true },
+    });
+
+    await this.prisma.user.update({
+      where: { id: decodedTokenPayload.userId },
+      data: { password: await hashPassword(newPassword) },
+    });
+  }
+}

--- a/src/user/dto/reset-password.request.dto.ts
+++ b/src/user/dto/reset-password.request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResetPasswordRequestBody {
+  @ApiProperty({
+    type: String,
+    required: true,
+  })
+  newPassword: string;
+  @ApiProperty({
+    type: String,
+    required: true,
+  })
+  token: string;
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -12,6 +12,7 @@ import { PrismaService } from '../database/prisma.service';
 import { CreateResetPasswordTokenCommand } from './commands/create-reset-password-token.command';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { ResetPasswordCommand } from './commands/reset-password.command';
 
 @Module({
   controllers: [UserController],
@@ -23,6 +24,7 @@ import { UserService } from './user.service';
     SubjectService,
     EmailService,
     CreateResetPasswordTokenCommand,
+    ResetPasswordCommand,
     JwtStrategy,
   ],
   imports: [

--- a/src/user/utils/decoded-token.ts
+++ b/src/user/utils/decoded-token.ts
@@ -1,0 +1,6 @@
+export class DecodedTokenPayload {
+  userId: number;
+  code: string;
+  expiresAt: Date;
+  iat: number;
+}

--- a/src/user/utils/exceptions.ts
+++ b/src/user/utils/exceptions.ts
@@ -11,3 +11,38 @@ export class ValidResetPasswordTokenFoundException extends Error {
     this.message = `Você já possui um token de resetar a senha válido!`;
   }
 }
+
+export class InvalidPasswordException extends Error {
+  constructor() {
+    super();
+    this.message = `A senha não atende aos padrões de senha do sistema!`;
+  }
+}
+
+export class InvalidCodeException extends Error {
+  constructor() {
+    super();
+    this.message = `O código presente no token é invalido!`;
+  }
+}
+
+export class InvalidTokenException extends Error {
+  constructor() {
+    super();
+    this.message = `O token não é válido!`;
+  }
+}
+
+export class ExpiredCodeException extends Error {
+  constructor() {
+    super();
+    this.message = `O código para resetar a senha expirou! `;
+  }
+}
+
+export class UsedCodeException extends Error {
+  constructor() {
+    super();
+    this.message = `O código para resetar a senha já foi usado! `;
+  }
+}


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 [DS-82] Cria rota para resetar senha](https://computero.atlassian.net/jira/software/projects/DS/boards/8?selectedIssue=DS-82)


<!-- O que este pull request faz? -->
Cria rota para resetar a senha de um usuario

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Entre na aplicacao, va ao swagger e gere um token de reset de senha na `rota user/reset-password/token`
- [ ] Va ao email, clique no link com e pegue o token codificado na url da pagina redirecionada
- [ ] Volte para o swagger, coloque o link como parametro da rota e faca os seguintes testes
- [ ] Coloque uma senha que saia dos padroes da plataforma e verifique se um erro eh levantado
- [ ] Coloque uma senha de acordo e verifique se a senha foi realmente trocada
- [ ] Mude a data de expiracao para ele ficar expirado e verifique se um erro foi levantado
- [ ] Mude o codigo do token e verifique se um erro foi levantado
- [ ] Use um token invalido (criado fora da aplicao ou incorreto mesmo) e verifique se um erro foi levantado
