### PR TITLE
feat: Adiciona rota de edição de usuários

### DIFF
--- a/src/user/commands/edit-user.command.ts
+++ b/src/user/commands/edit-user.command.ts
@@ -1,0 +1,215 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { UserEditDTO } from '../dto/user-edit.dto';
+import { Validations } from 'src/utils/validations';
+import {
+  ContactEmailAreadyExistsException,
+  CourseNotFoundException,
+  InvalidContactEmailException,
+  InvalidEnrollmentException,
+  InvalidLinkedinURLException,
+  InvalidNameException,
+  InvalidPasswordException,
+  InvalidStudentParametersException,
+  InvalidWhatsAppNumberException,
+  OldPasswordNotProvidedException,
+  WrongPasswordException,
+} from '../utils/exceptions';
+import { CourseService } from 'src/course/course.service';
+import { UserService } from '../user.service';
+import { comparePassword, hashPassword } from 'src/utils/bcrypt';
+import { Role } from 'src/auth/enums/role.enum';
+import { UserFactory } from '../utils/user.factory';
+import { Student } from '../domain/student';
+import { Teacher } from '../domain/teacher';
+import { Coordinator } from '../domain/coordinator';
+
+@Injectable()
+export class EditUserCommand {
+  constructor(
+    private prisma: PrismaService,
+    private courseService: CourseService,
+    private userService: UserService,
+  ) {}
+
+  async execute(
+    data: UserEditDTO,
+    userId: number,
+    userRole: string,
+  ): Promise<Student | Teacher | Coordinator> {
+    if (userRole !== Role.Student) {
+      this.verifyIfStudentParametersWerePassed(data);
+    }
+
+    this.verifyUserNameField(data);
+
+    await this.verifyUserPasswordField(data, userId);
+
+    await this.prisma.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        name: data.name,
+        password: data.password,
+      },
+    });
+
+    if (userRole === Role.Student) {
+      this.verifyStudentEnrollmentField(data);
+
+      await this.verifyStudentCourseIdField(data);
+
+      await this.verifyStudentContactEmailField(data);
+
+      this.verifyStudentLinkedinField(data);
+
+      this.verifyStudentWhatsAppField(data);
+
+      await this.prisma.student.update({
+        where: {
+          user_id: userId,
+        },
+        data: {
+          description: data.description,
+          enrollment: data.enrollment,
+          course_id: data.courseId,
+          contact_email: data.contactEmail,
+          whatsapp: data.whatsapp,
+          linkedin: data.linkedin,
+        },
+      });
+
+      const student = await this.prisma.student.findUnique({
+        where: {
+          user_id: userId,
+        },
+        include: {
+          user: true,
+          course: true,
+        },
+      });
+
+      return UserFactory.createStudent(student);
+    }
+
+    // TODO: Tratar os casos de professor e coordenador separadamente, ao invés de usar a tabela user.
+    const teacher = await this.prisma.user.findUnique({
+      where: {
+        id: userId,
+      },
+    });
+
+    return UserFactory.createTeacher(teacher);
+  }
+
+  /***********************************************************************************
+   * Private / Supportive methods
+   * *********************************************************************************
+   */
+  private verifyUserNameField(data: UserEditDTO) {
+    if (data.name) {
+      data.name = data.name.trim();
+      data.name = Validations.capitalizeName(data.name);
+      if (!Validations.validateName(data.name)) {
+        throw new InvalidNameException();
+      }
+    }
+  }
+
+  private async verifyUserPasswordField(data: UserEditDTO, userId: number) {
+    if (data.password) {
+      if (!data.oldPassword) {
+        throw new OldPasswordNotProvidedException();
+      }
+
+      await this.checkPasswordInDatabase(userId, data.oldPassword);
+
+      if (!Validations.validatePassword(data.password)) {
+        throw new InvalidPasswordException();
+      }
+
+      data.password = await hashPassword(data.password);
+    }
+  }
+
+  private async checkPasswordInDatabase(userId: number, oldPassword: string) {
+    const user = await this.prisma.user.findUnique({
+      where: {
+        id: userId,
+      },
+    });
+
+    const passwordsMatch = await comparePassword(oldPassword, user.password);
+    if (!passwordsMatch) {
+      throw new WrongPasswordException();
+    }
+  }
+
+  private verifyStudentEnrollmentField(data: UserEditDTO) {
+    if (data.enrollment) {
+      if (!Validations.validateEnrollment(data.enrollment)) {
+        throw new InvalidEnrollmentException();
+      }
+    }
+  }
+
+  private async verifyStudentCourseIdField(data: UserEditDTO) {
+    if (data.courseId) {
+      const course = await this.courseService.findCourseId(data.courseId);
+      if (course == null) throw new CourseNotFoundException();
+    }
+  }
+
+  private async verifyStudentContactEmailField(data: UserEditDTO) {
+    if (data.contactEmail) {
+      if (!Validations.validateEmailContact(data.contactEmail)) {
+        throw new InvalidContactEmailException();
+      }
+      const contact_email_exists = await this.userService.findOneByEmail(
+        data.contactEmail,
+      );
+
+      if (contact_email_exists) throw new ContactEmailAreadyExistsException();
+    }
+  }
+
+  private verifyStudentLinkedinField(data: UserEditDTO) {
+    if (data.linkedin) {
+      if (!Validations.validateLinkedIn(data.linkedin)) {
+        throw new InvalidLinkedinURLException();
+      }
+    }
+  }
+
+  private verifyStudentWhatsAppField(data: UserEditDTO) {
+    if (data.whatsapp) {
+      if (!Validations.validateWhatsapp(data.whatsapp)) {
+        throw new InvalidWhatsAppNumberException();
+      }
+    }
+  }
+
+  private verifyIfStudentParametersWerePassed(data: UserEditDTO) {
+    const studentData = {
+      description: data.description,
+      enrollment: data.enrollment,
+      courseId: data.courseId,
+      contactEmail: data.contactEmail,
+      whatsapp: data.whatsapp,
+      linkedin: data.linkedin,
+    };
+
+    const validStudentParametersArray = Object.entries(studentData).filter(
+      (element) => {
+        return element[1];
+      },
+    );
+
+    if (validStudentParametersArray.length > 0) {
+      const obj = Object.fromEntries(validStudentParametersArray);
+      const parametersKeysArray = Object.keys(obj);
+      throw new InvalidStudentParametersException(parametersKeysArray);
+    }
+  }
+}

--- a/src/user/domain/coordinator.ts
+++ b/src/user/domain/coordinator.ts
@@ -1,0 +1,3 @@
+import { User } from './user';
+
+export class Coordinator extends User {}

--- a/src/user/domain/student.ts
+++ b/src/user/domain/student.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from './user';
+import { Course } from 'src/course/domain/course';
+
+export class Student extends User {
+  @ApiProperty({ type: String })
+  contactEmail: string;
+
+  @ApiProperty({ type: String })
+  description: string;
+
+  @ApiProperty({ type: String })
+  enrollment: string;
+
+  @ApiProperty({ type: String })
+  whatsapp?: string;
+
+  @ApiProperty({ type: String })
+  linkedin?: string;
+
+  @ApiProperty({ type: Number })
+  courseId?: number;
+
+  @ApiProperty({ type: Course })
+  course?: Course;
+}

--- a/src/user/domain/teacher.ts
+++ b/src/user/domain/teacher.ts
@@ -1,0 +1,3 @@
+import { User } from './user';
+
+export class Teacher extends User {}

--- a/src/user/dto/user-edit.dto.ts
+++ b/src/user/dto/user-edit.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class UserEditDTO {
+  @IsOptional()
+  @IsString()
+  @ApiProperty()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty()
+  password?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty()
+  oldPassword?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty()
+  enrollment?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @ApiProperty()
+  courseId?: number;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty()
+  contactEmail?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty()
+  whatsapp?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty()
+  linkedin?: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -28,20 +28,34 @@ import {
   InvalidPasswordException,
   InvalidTokenException,
   UsedCodeException,
-  UserNotFoundException,
   ValidResetPasswordTokenFoundException,
+  UserNotFoundException,
+  MissingFieldsException,
+  ContactEmailAreadyExistsException,
+  CourseNotFoundException,
+  EmailAreadyExistsException,
+  EnrollmentAlreadyExistsException,
+  InvalidEmailException,
+  InvalidEnrollmentException,
+  InvalidLinkedinURLException,
+  InvalidNameException,
+  InvalidWhatsAppNumberException,
+  PasswordsDoNotMatchException,
+  PersonalDataInPasswordException,
+  InvalidContactEmailException,
 } from 'src/user/utils/exceptions';
-import { CreateResetPasswordTokenCommand } from './commands/create-reset-password-token.command';
 import { ResetPasswordCommand } from './commands/reset-password.command';
-import { ResetPasswordTokenRequestBody } from './dto/reset-password-token.request.dto';
 import { ResetPasswordRequestBody } from './dto/reset-password.request.dto';
 import { StudentCreateDTO } from './dto/student-create.dto';
 import { TeacherCreateDTO } from './dto/teacher-create.dto';
 import { GetUserInfoResponse } from './dto/user-info.response.dto';
 import { UserService } from './user.service';
 import { GetUserInfoCommand } from './commands/get-user-info.command';
-import { JwtService } from '@nestjs/jwt';
 import { JWTUser } from 'src/auth/interfaces/jwt-user.interface';
+import { ResetPasswordTokenRequestBody } from './dto/reset-password-token.request.dto';
+import { CreateResetPasswordTokenCommand } from './commands/create-reset-password-token.command';
+import {} from 'src/user/utils/exceptions';
+import { JwtService } from '@nestjs/jwt';
 
 @Controller('user')
 @ApiTags('User')
@@ -59,14 +73,61 @@ export class UserController {
   @Post('student')
   @IsPublic()
   async createUserStudent(@Body() data: StudentCreateDTO) {
-    return this.userService.createUserStudent(data);
+    try {
+      return await this.userService.createUserStudent(data);
+    } catch (error) {
+      if (
+        error instanceof MissingFieldsException ||
+        error instanceof InvalidNameException ||
+        error instanceof InvalidEmailException ||
+        error instanceof EmailAreadyExistsException ||
+        error instanceof ContactEmailAreadyExistsException ||
+        error instanceof CourseNotFoundException ||
+        error instanceof InvalidEnrollmentException ||
+        error instanceof InvalidPasswordException ||
+        error instanceof PersonalDataInPasswordException ||
+        error instanceof PasswordsDoNotMatchException ||
+        error instanceof InvalidLinkedinURLException ||
+        error instanceof InvalidWhatsAppNumberException ||
+        error instanceof EnrollmentAlreadyExistsException
+      ) {
+        throw new BadRequestException(error.message);
+      }
+
+      if (error instanceof CourseNotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+
+      throw error;
+    }
   }
 
   @ApiOperation({ description: 'Rota para criar usuário-professor.' })
   @Post('teacher')
   @IsPublic()
   async createUserTeacher(@Body() data: TeacherCreateDTO) {
-    return this.userService.createUserTeacher(data);
+    try {
+      return await this.userService.createUserTeacher(data);
+    } catch (error) {
+      if (
+        error instanceof MissingFieldsException ||
+        error instanceof InvalidNameException ||
+        error instanceof InvalidEmailException ||
+        error instanceof InvalidContactEmailException ||
+        error instanceof EmailAreadyExistsException ||
+        error instanceof InvalidPasswordException ||
+        error instanceof PersonalDataInPasswordException ||
+        error instanceof PasswordsDoNotMatchException
+      ) {
+        throw new BadRequestException(error.message);
+      }
+
+      if (error instanceof CourseNotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+
+      throw error;
+    }
   }
 
   @ApiOperation({ description: 'Rota para listar todos os usuários.' })

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
+import { JwtModule, JwtService } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from 'src/auth/strategies/jwt.strategy';
 import { CourseService } from 'src/course/course.service';
@@ -14,6 +14,7 @@ import { GetUserInfoCommand } from './commands/get-user-info.command';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { ResetPasswordCommand } from './commands/reset-password.command';
+import { EditUserCommand } from './commands/edit-user.command';
 
 @Module({
   controllers: [UserController],
@@ -24,9 +25,11 @@ import { ResetPasswordCommand } from './commands/reset-password.command';
     CourseService,
     SubjectService,
     EmailService,
+    JwtService,
     CreateResetPasswordTokenCommand,
     ResetPasswordCommand,
     GetUserInfoCommand,
+    EditUserCommand,
     JwtStrategy,
   ],
   imports: [

--- a/src/user/utils/exceptions.ts
+++ b/src/user/utils/exceptions.ts
@@ -46,3 +46,108 @@ export class UsedCodeException extends Error {
     this.message = `O código para resetar a senha já foi usado! `;
   }
 }
+
+export class MissingFieldsException extends Error {
+  constructor() {
+    super();
+    this.message = `Preencha todos os campos.`;
+  }
+}
+
+export class InvalidNameException extends Error {
+  constructor() {
+    super();
+    this.message = `O nome deve ter no mínimo um nome, sobrenome e no máximo 50 caracteres.`;
+  }
+}
+
+export class InvalidEmailException extends Error {
+  constructor() {
+    super();
+    this.message = `E-mail não é válido!`;
+  }
+}
+
+export class InvalidContactEmailException extends Error {
+  constructor() {
+    super();
+    this.message = `E-mail de contato não é válido!`;
+  }
+}
+
+export class EmailAreadyExistsException extends Error {
+  constructor() {
+    super();
+    this.message = `E-mail já cadastrado.`;
+  }
+}
+
+export class ContactEmailAreadyExistsException extends Error {
+  constructor() {
+    super();
+    this.message = `E-mail de contato já cadastrado.`;
+  }
+}
+
+export class CourseNotFoundException extends Error {
+  constructor() {
+    super();
+    this.message = `Curso não encontrado!`;
+  }
+}
+
+export class InvalidEnrollmentException extends Error {
+  constructor() {
+    super();
+    this.message = `Matrícula não atende aos requisitos!`;
+  }
+}
+
+export class PersonalDataInPasswordException extends Error {
+  constructor() {
+    super();
+    this.message = `A senha não deve conter dados pessoais como nome ou matricula.`;
+  }
+}
+
+export class PasswordsDoNotMatchException extends Error {
+  constructor() {
+    super();
+    this.message = `As senhas não são iguais!`;
+  }
+}
+
+export class InvalidLinkedinURLException extends Error {
+  constructor() {
+    super();
+    this.message = `Link do perfil do Linkedin não é compatível.`;
+  }
+}
+
+export class InvalidWhatsAppNumberException extends Error {
+  constructor() {
+    super();
+    this.message = `Número do WhatsApp inválido.`;
+  }
+}
+
+export class EnrollmentAlreadyExistsException extends Error {
+  constructor() {
+    super();
+    this.message = `Matrícula já cadastrada.`;
+  }
+}
+
+export class OldPasswordNotProvidedException extends Error {
+  constructor() {
+    super();
+    this.message = `Para criar uma nova senha, a senha antiga deve ser fornecida.`;
+  }
+}
+
+export class WrongPasswordException extends Error {
+  constructor() {
+    super();
+    this.message = `A senha informada não confere com os dados armazenados no sistema.`;
+  }
+}

--- a/src/user/utils/exceptions.ts
+++ b/src/user/utils/exceptions.ts
@@ -151,3 +151,14 @@ export class WrongPasswordException extends Error {
     this.message = `A senha informada não confere com os dados armazenados no sistema.`;
   }
 }
+
+export class InvalidStudentParametersException extends Error {
+  constructor(paramArray: Array<any>) {
+    super();
+    this.message =
+      'Os seguintes parâmetros só podem ser usados para usuários do tipo Estudante:';
+    paramArray.forEach((parameter) => {
+      this.message += ` ${parameter};`;
+    });
+  }
+}

--- a/src/user/utils/user.factory.ts
+++ b/src/user/utils/user.factory.ts
@@ -1,0 +1,45 @@
+import { Coordinator } from '../domain/coordinator';
+import { Student } from '../domain/student';
+import { Teacher } from '../domain/teacher';
+
+export class UserFactory {
+  static createStudent(prismaStudent): Student {
+    const student: Student = {
+      id: prismaStudent.user_id,
+      name: prismaStudent.user.name,
+      email: prismaStudent.user.email,
+      contactEmail: prismaStudent.contact_email,
+      description: prismaStudent.description,
+      enrollment: prismaStudent.enrollment,
+      whatsapp: prismaStudent.whatsapp,
+      linkedin: prismaStudent.linkedin,
+      courseId: prismaStudent.course_id,
+      course: prismaStudent.course && {
+        id: prismaStudent.course.id,
+        name: prismaStudent.course.name,
+      },
+    };
+
+    return student;
+  }
+
+  static createTeacher(prismaTeacher): Teacher {
+    const teacher: Teacher = {
+      id: prismaTeacher.id,
+      name: prismaTeacher.name,
+      email: prismaTeacher.email,
+    };
+
+    return teacher;
+  }
+
+  static createCoordinator(prismaCoordinator): Coordinator {
+    const coordinator: Coordinator = {
+      id: prismaCoordinator.id,
+      name: prismaCoordinator.name,
+      email: prismaCoordinator.email,
+    };
+
+    return coordinator;
+  }
+}


### PR DESCRIPTION
# Descrição

[📌 Criar rota de editar dados de usuário](https://computero.atlassian.net/browse/DS-107)

Esta PR:
- Altera o arquivo userService para deixar de lançar exceções HTTP, deixando essa responsabilidade apenas no controlador;
- Altera o arquivo de exceções para tornar os erros de validação reutilizáveis (foram reutilizados na rota de edição);
- Adiciona a rota `PATCH /user` para editar dados do usuário logado;

# Setup

- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make build up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

## 1. Cenário A - Editar dados de estudante**

- [ ] Na rota `PATCH /user`, tente alterar dados de estudante como `contactEmail` ou `whatsapp`
- [ ] Verifique que o retorno foi 200 (OK)
- [ ] Tente alterar sua senha, sem preencher o campo `oldPassword`
- [ ] Verifique que o retorno foi um erro.
- [ ] Tente alterar sua senha novamente, porém desta vez preenchendo o campo `oldPassword` com uma senha incorreta
- [ ] Verifique que o retorno foi um erro.
- [ ] Tente novamente alterar a senha, porém passando a senha correta para o campo `oldPassword`.
- [ ] Verifique que o retorno foi 200 (OK)

## 2. Cenário B - Editar dados de professor**

- [ ] Faça login com a conta `camila.professor@icomp.ufam.edu.br | 12345678`
- [ ] Tente alterar seu nome ou senha
- [ ] Verifique que o retorno foi 200 (OK)
- [ ] Tente fazer a requisição com dados de estudante, como `whatsapp` ou `contactEmail`
- [ ] Verifique que foi retornado um erro (importante, pois professores não possuem os campos de estudante)
