### PR TITLE
feat: Esconde swagger no ambiente de produção

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,24 +19,26 @@ async function bootstrap() {
     credentials: true,
   });
 
-  const config = new DocumentBuilder()
-    .setTitle('Super Monitoria API')
-    .setDescription('Backend Super Monitoria')
-    .setVersion('1.0')
-    .addTag('Super Monitoria')
-    .addBearerAuth({
-      description: 'Please enter token in following format: Bearer <JWT>',
-      name: 'Authorization',
-      bearerFormat: 'Bearer',
-      scheme: 'Bearer',
-      type: 'http',
-      in: 'Header',
-    })
-    .build();
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('Super Monitoria API')
+      .setDescription('Backend Super Monitoria')
+      .setVersion('1.0')
+      .addTag('Super Monitoria')
+      .addBearerAuth({
+        description: 'Please enter token in following format: Bearer <JWT>',
+        name: 'Authorization',
+        bearerFormat: 'Bearer',
+        scheme: 'Bearer',
+        type: 'http',
+        in: 'Header',
+      })
+      .build();
 
-  const document = SwaggerModule.createDocument(app, config);
+    const document = SwaggerModule.createDocument(app, config);
 
-  SwaggerModule.setup('/swagger', app, document);
+    SwaggerModule.setup('/swagger', app, document);
+  }
 
   await app.init();
 


### PR DESCRIPTION
# Descrição

[📌 Não gerar swagger em produção](https://computero.atlassian.net/browse/DS-95)

Este commit altera o arquivo `main.ts` para gerar a documentação do swagger apenas nos casos onde a variávei `NODE_ENV` for diferente de 'production'. 

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS) ou dev.
- [ ] Altere o arquivo Makefile temporariamente na linha 59. Troque a palavra `master` por `development`
- [ ] Suba a API com `make deploy-prod`
- [ ] Acesse o link `localhost:3003` e verifique que não foi gerada a página do Swagger contendo as rotas da aplicação.

*OBS: Não esqueça de descartar as alterações no arquivo Makefile posteriomente. Elas são apenas para fins de teste.*
