### PR TITLE
fix: Adiciona await aos envios de e-mail

### DIFF
--- a/src/monitor/commands/accept-schedule.command.ts
+++ b/src/monitor/commands/accept-schedule.command.ts
@@ -50,7 +50,7 @@ export class AcceptScheduleCommand {
       where: { id: userId },
     });
 
-    this.emailService.sendAcceptedScheduleEmail(
+    await this.emailService.sendAcceptedScheduleEmail(
       schedule.student.contact_email,
       'Confirmado',
       user.name,

--- a/src/monitor/commands/refuse-scheduled-monitoring.command.ts
+++ b/src/monitor/commands/refuse-scheduled-monitoring.command.ts
@@ -39,7 +39,7 @@ export class RefuseScheduledMonitoringCommand {
 
     const email = schedule.student.contact_email;
 
-    this.emailService.sendEmailRefuseScheduledMonitoring(email);
+    await this.emailService.sendEmailRefuseScheduledMonitoring(email);
 
     return { message: 'Agendamento rejeitado!' };
   }

--- a/src/monitor/monitor.service.ts
+++ b/src/monitor/monitor.service.ts
@@ -75,7 +75,12 @@ export class MonitorService {
     const context = { student_name: user.name, subject_name: subject.name };
     const template = 'request_monitor';
 
-    this.emailService.sendEmailRequestMonitoring(email, sub, context, template);
+    await this.emailService.sendEmailRequestMonitoring(
+      email,
+      sub,
+      context,
+      template,
+    );
 
     await this.prismaService.monitor.create({
       data: {
@@ -133,7 +138,7 @@ export class MonitorService {
     const template = 'accept_monitor';
     const subject_id = request_monitor.subject_id;
 
-    this.emailService.sendEmailAcceptMonitoring(
+    await this.emailService.sendEmailAcceptMonitoring(
       email,
       sub,
       template,
@@ -187,7 +192,7 @@ export class MonitorService {
     const sub = 'Obrigado por tentar...';
     const template = 'refuse_monitor';
 
-    this.emailService.sendEmailRefuseMonitoring(email, sub, template);
+    await this.emailService.sendEmailRefuseMonitoring(email, sub, template);
 
     return { message: 'Solicitacão recusada!' };
   }

--- a/src/student/commands/schedule-monitoring.command.ts
+++ b/src/student/commands/schedule-monitoring.command.ts
@@ -83,7 +83,7 @@ export class ScheduleMonitoringCommand {
       };
       const template = 'schedule_monitoring';
 
-      this.emailService.sendEmailScheduleMonitoring(
+      await this.emailService.sendEmailScheduleMonitoring(
         email,
         sub,
         context,


### PR DESCRIPTION
# Descrição

Esta PR corrige um bug onde rotas que acionavam notificações de e-mail estavam sendo retornadas sem o devido envio dos e-mails para os usuários. Foram adicionados os devidos `await` em todas as partes onde o envio de emails era necessário, para mitigar esse problema e garantir que o e-mail foi enviado antes do retorno da rota.