### PR TITLE
feat: Rota de criacao de topico

### DIFF
--- a/src/schedules/commands/create-topic.command.ts
+++ b/src/schedules/commands/create-topic.command.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { Topic } from '../dto/topic.dto';
+import { ScheduleTopicFormatter } from '../utils/schedule-topic-formatter';
+
+@Injectable()
+export class CreateTopicCommand {
+  constructor(private prisma: PrismaService) {}
+
+  async execute(name: string): Promise<Topic> {
+    const formattedName = ScheduleTopicFormatter.formatScheduleTopicName(name);
+
+    const token = ScheduleTopicFormatter.formatScheduleTopicToken(name);
+
+    const topic = await this.prisma.scheduleTopics.create({
+      data: {
+        name: formattedName,
+        token,
+      },
+    });
+
+    return topic;
+  }
+}

--- a/src/schedules/domain/schedule.ts
+++ b/src/schedules/domain/schedule.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Subject } from 'src/subject/domain/subject';
 import { User } from 'src/user/domain/user';
 import { ScheduleStatus } from '../utils/schedules.enum';
+import { Topic } from '../dto/topic.dto';
 
 class Student extends User {
   @ApiProperty({ type: String })
@@ -40,4 +41,7 @@ export class Schedule {
 
   @ApiProperty({ type: Subject })
   subject?: Subject;
+
+  @ApiProperty({ type: Topic })
+  topic?: Topic;
 }

--- a/src/schedules/dto/create-topic.request.dto.ts
+++ b/src/schedules/dto/create-topic.request.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateTopicRequestBody {
+  @ApiProperty({
+    type: String,
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}

--- a/src/schedules/dto/topic.dto.ts
+++ b/src/schedules/dto/topic.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Topic {
+  @ApiProperty({
+    type: Number,
+  })
+  id: number;
+
+  @ApiProperty({
+    type: String,
+  })
+  name: string;
+
+  @ApiProperty({
+    type: String,
+  })
+  token: string;
+
+  @ApiProperty({
+    type: Date,
+  })
+  updated_at: Date;
+
+  @ApiProperty({
+    type: Date,
+  })
+  created_at: Date;
+}

--- a/src/schedules/schedules.controller.ts
+++ b/src/schedules/schedules.controller.ts
@@ -40,6 +40,9 @@ import {
   ProfessorNotAuthorizedException,
   ScheduleNotFoundException,
 } from './utils/exceptions';
+import { CreateTopicRequestBody } from './dto/create-topic.request.dto';
+import { CreateTopicCommand } from './commands/create-topic.command';
+import { Topic } from './dto/topic.dto';
 
 @Controller('schedules')
 @ApiTags('Schedules')
@@ -49,6 +52,7 @@ export class SchedulesController {
     private readonly endScheduleCommand: EndScheduleCommand,
     private readonly listSchedulesCommand: ListSchedulesCommand,
     private readonly listEndingSchedulesCommand: ListEndingSchedulesCommand,
+    private readonly createTopicCommand: CreateTopicCommand,
     private readonly jwtService: JwtService,
   ) {}
 
@@ -192,6 +196,17 @@ export class SchedulesController {
         throw new NotFoundException(error.message);
       }
 
+      throw error;
+    }
+  }
+
+  @ApiBearerAuth()
+  @Roles(Role.Student)
+  @Post('topics')
+  async createTopic(@Body() body: CreateTopicRequestBody): Promise<Topic> {
+    try {
+      return await this.createTopicCommand.execute(body.name);
+    } catch (error) {
       throw error;
     }
   }

--- a/src/schedules/schedules.module.ts
+++ b/src/schedules/schedules.module.ts
@@ -7,6 +7,7 @@ import { EndScheduleCommand } from './commands/end-schedule.command';
 import { ListEndingSchedulesCommand } from './commands/list-ending-schedules.command';
 import { ListSchedulesCommand } from './commands/list-schedules.command';
 import { SchedulesController } from './schedules.controller';
+import { CreateTopicCommand } from './commands/create-topic.command';
 
 @Module({
   providers: [
@@ -14,6 +15,7 @@ import { SchedulesController } from './schedules.controller';
     EndScheduleCommand,
     ListSchedulesCommand,
     ListEndingSchedulesCommand,
+    CreateTopicCommand,
     JwtService,
     EmailService,
     PrismaService,

--- a/src/schedules/utils/schedule-topic-formatter.ts
+++ b/src/schedules/utils/schedule-topic-formatter.ts
@@ -1,0 +1,29 @@
+export class ScheduleTopicFormatter {
+  static formatScheduleTopicName(name: string): string {
+    return name
+      .trim()
+      .split(/\s+/)
+      .map((word) => {
+        let formatedString: string = word.charAt(0).toUpperCase();
+
+        for (let i = 1; i < word.length; i++) {
+          if (word[i - 1] == '-')
+            formatedString = formatedString + word[i].toUpperCase();
+          else formatedString = formatedString + word[i].toLowerCase();
+        }
+
+        return formatedString;
+      })
+      .join(' ');
+  }
+
+  static formatScheduleTopicToken(name: string): string {
+    return name
+      .toUpperCase()
+      .replace(/\s/g, '')
+      .replace(/[0-9]/g, '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^\w\s]/g, '');
+  }
+}


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 [DS-157] Criar rota para criar um novo assunto de agendamento](https://computero.atlassian.net/jira/software/projects/DS/boards/8?selectedIssue=DS-157)


<!-- O que este pull request faz? -->
Cria rota de criacao de topico

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Gere um topico 

- [ ] Rode a aplicacao e entre no swagger
- [ ] Va para rota `schedules/topics` e faca os testes
- [ ] Tente rodar sem estar logado. Um erro deve aparecer
- [ ] Faca login e tente rodar sem o campo do `name` ou com uma string vazia. Um erro deve aparecer nos dois casos
- [ ]  Por fim teste se as transformacoes no `name` se adequam ao requisitado no card
- [ ] No campo `name`, a string precisa: **estar capitalizada* e **sem espacos desnecessarios**. Ex: “  Árvore   RUBRO-Negra  " deve virar “Árvore Rubro-Negra"
- [ ] No campo `token`, a string precisa: **estar toda em caixa alta**, **sem espacos**, **sem numeros**, **sem acentos, pontuacoes ou caracteres especiais**. Ex: “Árvore Rubro-Negra" precisa virar “ARVORERUBRONEGRA"
