### PR TITLE
fix: Altera course_id para course_name

### DIFF
--- a/src/user/commands/get-user-info.command.ts
+++ b/src/user/commands/get-user-info.command.ts
@@ -9,7 +9,7 @@ export class GetUserInfoCommand {
   async execute(userId: number): Promise<GetUserInfoResponse> {
     const user = await this.prisma.user.findFirst({
       where: { id: userId },
-      include: { student: true },
+      include: { student: { include: { course: true } } },
     });
 
     if (!user.student) {
@@ -21,7 +21,7 @@ export class GetUserInfoCommand {
       email: user.email,
       description: user.student?.description,
       enrollment: user.student?.enrollment,
-      course_id: user.student?.course_id,
+      course: { id: user.student?.course_id, name: user.student?.course?.name },
       contact_email: user.student?.contact_email,
       whatsapp: user.student?.whatsapp,
       linkedin: user.student?.linkedin,

--- a/src/user/dto/user-info.response.dto.ts
+++ b/src/user/dto/user-info.response.dto.ts
@@ -18,7 +18,7 @@ export class GetUserInfoResponse {
 
   @ApiProperty()
   @IsOptional()
-  course_id?: number;
+  course?: any;
 
   @ApiProperty()
   @IsOptional()


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Rota de dados do usuário logado](https://computero.atlassian.net/jira/software/projects/DS/boards/8?selectedIssue=DS-131)

- Na rota de dados do usuário logado o atributo curso retorna um número: id do curso, é mais interessante retornar o nome do curso para evitar uma nova consulta. Foi alterado o atributo de resposta para o course_name
# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de dev.
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta de estudante (Conta de Professores ou Coordenadores trazem os  dados cadastrais como nulos).
# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Acessar a rota autenticado
- [ ] Verificar se trouxe os dados cadastrados com o course_name