### PR TITLE
feat: Adiciona rota de listar assuntos

### DIFF
--- a/src/schedules/commands/get-topics.command.ts
+++ b/src/schedules/commands/get-topics.command.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { TopicFactory } from '../utils/topic.fatory';
+import { GetTopicsResponse } from '../dto/get-topics.response.dto';
+import { ScheduleTopicFormatter } from '../utils/schedule-topic-formatter';
+
+@Injectable()
+export class GetTopicsCommand {
+  constructor(private prisma: PrismaService) {}
+
+  async execute(
+    name: string,
+    page: number,
+    pageSize: number,
+  ): Promise<GetTopicsResponse> {
+    let token: string;
+    if (name) {
+      token = ScheduleTopicFormatter.formatScheduleTopicToken(name);
+    }
+
+    const where = {
+      token: { contains: token },
+    };
+    const take = pageSize || 10;
+    const skip = page ? (page - 1) * take : 0;
+
+    const response = await this.prisma.scheduleTopics.findMany({
+      orderBy: {
+        token: 'asc',
+      },
+      where,
+      skip,
+      take,
+    });
+
+    const totalItems = await this.prisma.scheduleTopics.count({ where });
+
+    return {
+      data: response.map(TopicFactory.createFromPrisma),
+      meta: {
+        page: page || 1,
+        pageSize: take,
+        totalItems,
+        totalPages: Math.ceil(totalItems / take),
+      },
+    };
+  }
+}

--- a/src/schedules/domain/topic.ts
+++ b/src/schedules/domain/topic.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Topic {
+  @ApiProperty({
+    type: Number,
+  })
+  id: number;
+
+  @ApiProperty({
+    type: String,
+  })
+  name: string;
+
+  @ApiProperty({
+    type: String,
+  })
+  token: string;
+}

--- a/src/schedules/dto/get-topics.request.dto.ts
+++ b/src/schedules/dto/get-topics.request.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsOptional, IsString } from 'class-validator';
+
+export class GetTopicsQueryParams {
+  @ApiProperty({
+    required: false,
+    description: 'Buscar assunto pelo nome',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  name: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Quantidade de registros por página',
+    default: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  pageSize: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'Número da página',
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  page: number;
+}

--- a/src/schedules/dto/get-topics.response.dto.ts
+++ b/src/schedules/dto/get-topics.response.dto.ts
@@ -1,0 +1,4 @@
+import { Topic } from '../domain/topic';
+import { PaginationResponse } from 'src/common/dto/query-pagination.dto';
+
+export class GetTopicsResponse extends PaginationResponse<Topic> {}

--- a/src/schedules/schedules.controller.ts
+++ b/src/schedules/schedules.controller.ts
@@ -43,6 +43,9 @@ import {
 import { CreateTopicRequestBody } from './dto/create-topic.request.dto';
 import { CreateTopicCommand } from './commands/create-topic.command';
 import { Topic } from './dto/topic.dto';
+import { GetTopicsCommand as GetScheduleTopicsCommand } from './commands/get-topics.command';
+import { GetTopicsQueryParams } from './dto/get-topics.request.dto';
+import { GetTopicsResponse } from './dto/get-topics.response.dto';
 
 @Controller('schedules')
 @ApiTags('Schedules')
@@ -50,6 +53,7 @@ export class SchedulesController {
   constructor(
     private readonly cancelScheduleCommand: CancelScheduleCommand,
     private readonly endScheduleCommand: EndScheduleCommand,
+    private readonly getScheduleTopicsCommand: GetScheduleTopicsCommand,
     private readonly listSchedulesCommand: ListSchedulesCommand,
     private readonly listEndingSchedulesCommand: ListEndingSchedulesCommand,
     private readonly createTopicCommand: CreateTopicCommand,
@@ -244,6 +248,22 @@ export class SchedulesController {
         throw new PreconditionFailedException(error.message);
       }
 
+      throw error;
+    }
+  }
+
+  @ApiBearerAuth()
+  @Get('topics')
+  async getTopics(
+    @Query() query: GetTopicsQueryParams,
+  ): Promise<GetTopicsResponse> {
+    try {
+      return await this.getScheduleTopicsCommand.execute(
+        query.name,
+        query.page,
+        query.pageSize,
+      );
+    } catch (error) {
       throw error;
     }
   }

--- a/src/schedules/schedules.module.ts
+++ b/src/schedules/schedules.module.ts
@@ -8,11 +8,13 @@ import { ListEndingSchedulesCommand } from './commands/list-ending-schedules.com
 import { ListSchedulesCommand } from './commands/list-schedules.command';
 import { SchedulesController } from './schedules.controller';
 import { CreateTopicCommand } from './commands/create-topic.command';
+import { GetTopicsCommand } from './commands/get-topics.command';
 
 @Module({
   providers: [
     CancelScheduleCommand,
     EndScheduleCommand,
+    GetTopicsCommand,
     ListSchedulesCommand,
     ListEndingSchedulesCommand,
     CreateTopicCommand,

--- a/src/schedules/utils/topic.fatory.ts
+++ b/src/schedules/utils/topic.fatory.ts
@@ -1,0 +1,13 @@
+import { Topic } from '../domain/topic';
+
+export class TopicFactory {
+  static createFromPrisma(prismaTopic): Topic {
+    const topic: Topic = {
+      id: prismaTopic.id,
+      name: prismaTopic.name,
+      token: prismaTopic.token,
+    };
+
+    return topic;
+  }
+}

--- a/src/student/commands/schedule-monitoring.command.ts
+++ b/src/student/commands/schedule-monitoring.command.ts
@@ -72,7 +72,7 @@ export class ScheduleMonitoringCommand {
     });
 
     //TODO Aguardando o resultado da rota.
-    const topic = ''
+    const topic = '';
 
     if (newSchedule) {
       const email = monitor.student.contact_email;


### PR DESCRIPTION
# Descrição

[📌 Criar rota para buscar assuntos de agendamento](https://computero.atlassian.net/browse/DS-156)


Este PR: 
- Adiciona rota para listar assuntos de agendamento

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

## 1. Cenário A**

- [ ] Na rota `POST /schedules/topic`, crie um assunto de agendamento de sua preferência.
- [ ] Na rota desta PR, `GET /schedules/topic`, busque pelo assunto de agendamento que você criou no passo anterior, utilizando o campo `name` como busca.
- [ ] Acesse a mesma rota anterior, porém, sem nenhum parâmetro de busca, e veja se foram retornados todos os assuntos de agendamento disponíveis no banco de dados.