### PR TITLE
feat: Alterar rota de agendamento para receber assunto

### DIFF
--- a/src/schedules/utils/schedule.factory.ts
+++ b/src/schedules/utils/schedule.factory.ts
@@ -8,6 +8,7 @@ export class ScheduleFactory {
       endDate: prismaSchedule.end,
       status: prismaSchedule.id_status,
       description: prismaSchedule.description,
+      topic: prismaSchedule.ScheduleTopics,
     };
 
     if (!!prismaSchedule.monitor) {

--- a/src/schedules/utils/select-schedule.prisma-sql.ts
+++ b/src/schedules/utils/select-schedule.prisma-sql.ts
@@ -24,6 +24,12 @@ const scheduleSelectPrismaSQL = {
   end: true,
   description: true,
   ...studentSelect,
+  ScheduleTopics: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
   monitor: {
     select: {
       id: true,

--- a/src/student/commands/list-student-schedules.command.ts
+++ b/src/student/commands/list-student-schedules.command.ts
@@ -50,6 +50,12 @@ export class ListStudentSchedulesCommand {
         start: { gte: today.toISOString() },
       },
       include: {
+        ScheduleTopics: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
         monitor: { include: { student: studentInclude, subject: true } },
         student: studentInclude,
       },

--- a/src/student/dto/schedule-monitoring.dto.ts
+++ b/src/student/dto/schedule-monitoring.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsOptional, IsNumber, IsString, MaxLength } from 'class-validator';
 
 export class ScheduleMonitoringDto {
   @ApiProperty({
@@ -14,6 +14,10 @@ export class ScheduleMonitoringDto {
   })
   @Transform(({ value }) => value && new Date(value))
   end: Date;
+
+  @ApiProperty()
+  @IsNumber()
+  topicId: number;
 
   @ApiProperty()
   @IsString()

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -28,6 +28,7 @@ import {
   NotAnAvailableTimeException,
   SameStudentException,
   StudentTimeAlreadyScheduledException,
+  TopicNotFoundException,
 } from './utils/exceptions';
 
 @ApiTags('Students')
@@ -57,7 +58,10 @@ export class StudentController {
         body,
       );
     } catch (error) {
-      if (error instanceof MonitorNotFoundException) {
+      if (
+        error instanceof MonitorNotFoundException ||
+        error instanceof TopicNotFoundException
+      ) {
         throw new NotFoundException(error.message);
       }
 

--- a/src/student/utils/exceptions.ts
+++ b/src/student/utils/exceptions.ts
@@ -46,3 +46,10 @@ export class StudentTimeAlreadyScheduledException extends Error {
     this.message = `Aluno(a) já possui um agendamento com status '${status}' no horário solicitado`;
   }
 }
+
+export class TopicNotFoundException extends Error {
+  constructor() {
+    super();
+    this.message = `Assunto não encontrado`;
+  }
+}


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Alterar rota de agendamento para receber assunto](https://computero.atlassian.net/jira/software/projects/DS/boards/8?selectedIssue=DS-184)


<!-- O que este pull request faz? -->
Comentário resumido sobre o objetivo do Pull Request
- Adiciona o parâmetro topicId no body da rota de agendamento para salvo o assunto escolhido pelo aluno: /student/{monitor_id}/schedule
- Retorna o assunto do agendamento nas rotas que retornam agendamentos: /student/schedules
- Envia o assunto para o template de e-mail da notificação.

# Pré-condições:
- [ ] Ter acesso a uma conta de estudante
- [ ] Ter acesso a uma conta de monitor
- [ ] Ter acesso ao e-mail da conta de monitor

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de dev
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta de estudante
- [ ] Solicite um agendamento na rota /student/{monitor_id}/schedule para um monitor no qual você tenha acesso ao email.

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Adicionar o ID de assunto existente (Tabela ScheduleTopics)
- [ ] Verificar se o agendamento foi feito com sucesso
- [ ] Verificar no email recebido se o nome do assunto veio corretamente
- [ ]  Verificar na rota /student/schedules se as informações foram trazidas corretamente

## 2. Cenário B**

- [ ] Adicionar o ID de assunto não existente (Tabela ScheduleTopics)
- [ ] Verificar se a rota trouxe um erro 
- [ ]  Verificar na rota /student/schedules se o agendamento não foi criado

