### PR TITLE
fix: Permite rodar make db-shell em todos os envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ db-seed:
 
 .PHONY: db-shell
 db-shell:
-	@docker-compose exec -it ${DB_SERVICE_NAME} mysql -uroot -proot -D ufam-dev
+	@docker-compose exec -it ${DB_SERVICE_NAME} mysql -uroot -p
 
 .PHONY: deploy-stg
 deploy-stg: down

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ We use Makefile commands to run our scripts:
   make db-seed
   ```
 
+- Access database through terminal:
+  ```bash
+  make db-shell
+  ```
+  - Insert password and run `use <db_name>;` to enter the database and run sql queries.
+
 ## Staging
 
 - Run API on production mode:


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Consertar makefile para acessar banco](https://computero.atlassian.net/browse/DS-189)


<!-- O que este pull request faz? -->
Remove senha e nome do banco do comando `db-shell` no Makefile para permitir que ele possa ser executado em prod e staging.

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
  - Estávamos passando a senha e o nome do banco de dev no comando `db-shell`, então quando tentamos rodar ele em stg ou prod não dá pra acessar o banco.
- O que foi feito para corrigi-lo?
  - Não passa mais a senha e o banco, deixa pro usuário colocar os dois de acordo com o ambiente

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco local.
- [ ] Suba a API com `make up`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Acessar banco

- [ ] Rode `make db-shell`
- [ ] Informe a senha `root`
- [ ] Execute o comando `use ufam-dev;`
- [ ] Verifique que o comando `select * from user;` deu certo.


