### PR TITLE
fix: Altera a rota de agendamento para o assunto ser opcional

### DIFF
--- a/src/student/commands/schedule-monitoring.command.ts
+++ b/src/student/commands/schedule-monitoring.command.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils/exceptions';
 import { Schedule } from 'src/schedules/domain/schedule';
 import { EmailService } from 'src/email/email.service';
+import { ScheduleTopics } from '@prisma/client';
 
 @Injectable()
 export class ScheduleMonitoringCommand {
@@ -58,11 +59,14 @@ export class ScheduleMonitoringCommand {
 
     await this.checkStudentSchedules(userId, start, end);
 
-    const topic = await this.prisma.scheduleTopics.findUnique({
-      where: { id: topicId },
-    });
+    let topic: ScheduleTopics;
 
-    if (!topic) throw new TopicNotFoundException();
+    if (topicId) {
+      topic = await this.prisma.scheduleTopics.findUnique({
+        where: { id: topicId },
+      });
+      if (!topic) throw new TopicNotFoundException();
+    }
 
     const newSchedule = await this.prisma.scheduleMonitoring.create({
       data: {
@@ -89,7 +93,7 @@ export class ScheduleMonitoringCommand {
         start: start.toLocaleTimeString('pt-BR').slice(0, 5),
         end: end.toLocaleTimeString('pt-BR').slice(0, 5),
         description: description,
-        topic: topic.name,
+        topic: topic?.name,
       };
       const template = 'schedule_monitoring';
 

--- a/src/student/dto/schedule-monitoring.dto.ts
+++ b/src/student/dto/schedule-monitoring.dto.ts
@@ -17,7 +17,8 @@ export class ScheduleMonitoringDto {
 
   @ApiProperty()
   @IsNumber()
-  topicId: number;
+  @IsOptional()
+  topicId?: number;
 
   @ApiProperty()
   @IsString()


### PR DESCRIPTION
### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
 - O Assunto (topic) deveria ser um parâmetro opcional, da forma que estava implementada impedia que um agendamento fosse feito sem um topicID
- O que foi feito para corrigi-lo?
 - Esse parâmetro foi alterado para ser opcional. Foi adicionada uma lógica para verificar se um topicId foi passado para ser lançada a exceção de erro corretamente. A busca no banco só é feita caso o usuário passe um topicId

# Pré-condições:
- [ ] Ter acesso a uma conta de estudante
- [ ] Ter acesso a uma conta de monitor
- [ ] Ter acesso ao e-mail da conta de monitor

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco local.
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta de estudante
- [ ] Solicite um agendamento na rota /student/{monitor_id}/schedule para um monitor no qual você tenha acesso ao email.

## 1. Cenário A**

- [ ] Adicionar o ID de assunto existente (Tabela ScheduleTopics).
- [ ] Verificar se o agendamento foi feito com sucesso.
- [ ] Verificar no email recebido se o nome do assunto veio corretamente.
- [ ]  Verificar na rota /student/schedules se as informações foram trazidas corretamente.

## 2. Cenário B**

- [ ] Adicionar o ID de assunto não existente (Tabela ScheduleTopics).
- [ ] Verificar se a rota trouxe um erro.
- [ ]  Verificar na rota /student/schedules se o agendamento não foi criado.

## 3. Cenário C**
- [ ] Fazer um agendamento retirando o campos topicId
- [ ] Verificar se o agendamento foi feito com sucesso.
- [ ] Verificar no email recebido se o nome do assunto veio em branco.
- [ ]  Verificar na rota /student/schedules se as informações foram trazidas corretamente.