### PR TITLE
fix: Corrige rota de edição de usuários

### DIFF
--- a/src/user/commands/edit-user.command.ts
+++ b/src/user/commands/edit-user.command.ts
@@ -109,6 +109,8 @@ export class EditUserCommand {
    * *********************************************************************************
    */
   private verifyUserNameField(data: UserEditDTO) {
+    if (data.name === undefined) return;
+
     data.name = data.name.trim();
     data.name = Validations.capitalizeName(data.name);
     if (!Validations.validateName(data.name)) {
@@ -117,6 +119,8 @@ export class EditUserCommand {
   }
 
   private async verifyUserPasswordField(data: UserEditDTO, userId: number) {
+    if (data.password === undefined) return;
+
     if (!data.oldPassword) {
       throw new OldPasswordNotProvidedException();
     }
@@ -144,17 +148,23 @@ export class EditUserCommand {
   }
 
   private verifyStudentEnrollmentField(data: UserEditDTO) {
+    if (data.enrollment === undefined) return;
+
     if (!Validations.validateEnrollment(data.enrollment)) {
       throw new InvalidEnrollmentException();
     }
   }
 
   private async verifyStudentCourseIdField(data: UserEditDTO) {
+    if (data.courseId === undefined) return;
+
     const course = await this.courseService.findCourseId(data.courseId);
     if (course == null) throw new CourseNotFoundException();
   }
 
   private async verifyStudentContactEmailField(data: UserEditDTO) {
+    if (data.contactEmail === undefined) return;
+
     if (!Validations.validateEmailContact(data.contactEmail)) {
       throw new InvalidContactEmailException();
     }
@@ -166,12 +176,16 @@ export class EditUserCommand {
   }
 
   private verifyStudentLinkedinField(data: UserEditDTO) {
+    if (data.linkedin === undefined) return;
+
     if (!Validations.validateLinkedIn(data.linkedin)) {
       throw new InvalidLinkedinURLException();
     }
   }
 
   private verifyStudentWhatsAppField(data: UserEditDTO) {
+    if (data.whatsapp === undefined) return;
+
     if (!Validations.validateWhatsapp(data.whatsapp)) {
       throw new InvalidWhatsAppNumberException();
     }


### PR DESCRIPTION
# Descrição

[📌 Criar rota de editar dados de usuário](https://computero.atlassian.net/browse/DS-107)

Este PR:
- Adiciona uma verificação extra no começo das validações para tratar strings vazias ou campos passados como **null**

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
O bug estava sendo gerado porque alguns campos quando estavam sendo passados como null, isto é, ocultos do body, geravam erro na request. 
- O que foi feito para corrigi-lo?
Adicionada verificação adicional para checar se o campo é undefined antes de iniciar as validações

# Setup

- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

## 1. Cenário A**

- [ ] Acesse a rota `PATCH/user` e tente alterar somente o nome de usuário, com um nome válido.
- [ ] Tente alterar o nome de usuário para uma string vazia: `""` e verifique que foi retornado erro
- [ ] Tente alterar a descrição para uma string vazia `""` e verifique que **não** foi retornado nenhum erro.
