### PR TITLE
chore: Adiciona script para popular o banco

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ db-seed:
 db-shell:
 	@docker-compose exec ${DB_SERVICE_NAME} mysql -uroot -p
 
+.PHONY: db-prune
+db-prune:
+	docker system prune -af --volumes
+
 .PHONY: deploy-stg
 deploy-stg: down
 	git pull origin staging && \

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,17 @@ db-migrate-create:
 db-seed:
 	@docker-compose exec ${API_SERVICE_NAME} node dist/prisma/seed.js
 
+.PHONY: db-populate
+db-populate:
+	@docker-compose exec ${API_SERVICE_NAME} node dist/prisma/populate.js
+
 .PHONY: db-shell
 db-shell:
 	@docker-compose exec ${DB_SERVICE_NAME} mysql -uroot -p
 
 .PHONY: db-prune
-db-prune:
-	docker system prune -af --volumes
+db-prune: down
+	docker volume rm backend_mysql_dev backend_mysql_config_dev 
 
 .PHONY: deploy-stg
 deploy-stg: down

--- a/prisma/mocks/coordinator.mock.ts
+++ b/prisma/mocks/coordinator.mock.ts
@@ -1,0 +1,8 @@
+export const coordinator = {
+  id: 10,
+  email: 'coordenador@icomp.ufam.edu.br',
+  name: 'Passito Coordenador',
+  password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+  is_verified: true,
+  type_user_id: 3,
+};

--- a/prisma/mocks/monitors.mock.ts
+++ b/prisma/mocks/monitors.mock.ts
@@ -1,0 +1,122 @@
+import { MonitorStatus } from 'src/monitor/utils/monitor.enum';
+
+export const monitors = [
+  {
+    monitorData: {
+      id: 1,
+      id_status: MonitorStatus.PENDING,
+      responsible_professor_id: 2,
+      student_id: 9,
+      subject_id: 1,
+    },
+    availableTimes: [],
+  },
+  {
+    monitorData: {
+      id: 2,
+      id_status: MonitorStatus.AVAILABLE,
+      responsible_professor_id: 2,
+      student_id: 6,
+      subject_id: 2,
+    },
+    availableTimes: [
+      {
+        id: 1,
+        week_day: 0,
+        start: '00:00',
+        end: '23:00',
+        monitor_id: 2,
+      },
+      {
+        id: 2,
+        week_day: 1,
+        start: '00:00',
+        end: '23:00',
+        monitor_id: 2,
+      },
+      {
+        id: 3,
+        week_day: 2,
+        start: '00:00',
+        end: '23:00',
+        monitor_id: 2,
+      },
+      {
+        id: 4,
+        week_day: 3,
+        start: '00:00',
+        end: '23:00',
+        monitor_id: 2,
+      },
+      {
+        id: 5,
+        week_day: 4,
+        start: '00:00',
+        end: '23:00',
+        monitor_id: 2,
+      },
+      {
+        id: 6,
+        week_day: 5,
+        start: '00:00',
+        end: '23:00',
+        monitor_id: 2,
+      },
+      {
+        id: 7,
+        week_day: 6,
+        start: '00:00',
+        end: '23:00',
+        monitor_id: 2,
+      },
+    ],
+  },
+  {
+    monitorData: {
+      id: 3,
+      id_status: MonitorStatus.DONE,
+      responsible_professor_id: 2,
+      student_id: 7,
+      subject_id: 1,
+    },
+    availableTimes: [],
+  },
+  {
+    monitorData: {
+      id: 4,
+      id_status: MonitorStatus.REJECTED,
+      responsible_professor_id: 2,
+      student_id: 7,
+      subject_id: 2,
+    },
+    availableTimes: [],
+  },
+  {
+    monitorData: {
+      id: 5,
+      id_status: MonitorStatus.AVAILABLE,
+      responsible_professor_id: 3,
+      student_id: 7,
+      subject_id: 1,
+    },
+    availableTimes: [
+      {
+        id: 8,
+        week_day: 0,
+        start: '12:00',
+        end: '14:00',
+        monitor_id: 5,
+      },
+    ],
+  },
+  {
+    monitorData: {
+      id: 6,
+      id_status: MonitorStatus.APPROVED,
+      responsible_professor_id: 2,
+      student_id: 8,
+      subject_id: 1,
+    },
+    availableTimes: [],
+  },
+];

--- a/prisma/mocks/schedules.mock.ts
+++ b/prisma/mocks/schedules.mock.ts
@@ -1,0 +1,58 @@
+import { ScheduleStatus } from 'src/schedules/utils/schedules.enum';
+
+export const schedules = [
+  {
+    id: 1,
+    start: new Date('2023-01-20 11:00:00'),
+    end: new Date('2023-01-20 12:00:00'),
+    id_status: ScheduleStatus.WAITING_APPROVAL,
+    student_id: 9,
+    monitor_id: 2,
+    description: '',
+  },
+  {
+    id: 2,
+    start: new Date('2023-01-20 12:20:00'),
+    end: new Date('2023-01-20 13:20:00'),
+    id_status: ScheduleStatus.CONFIRMED,
+    student_id: 9,
+    monitor_id: 2,
+    description: '',
+  },
+  {
+    id: 3,
+    start: new Date('2023-01-20 13:30:00'),
+    end: new Date('2023-01-20 14:30:00'),
+    id_status: ScheduleStatus.CANCELED,
+    student_id: 9,
+    monitor_id: 2,
+    description: '',
+  },
+  {
+    id: 4,
+    start: new Date('2023-01-20 15:00:00'),
+    end: new Date('2023-01-20 16:00:00'),
+    id_status: ScheduleStatus.REALIZED,
+    student_id: 9,
+    monitor_id: 2,
+    description: '',
+  },
+  {
+    id: 5,
+    start: new Date('2023-01-20 17:00:00'),
+    end: new Date('2023-01-20 18:00:00'),
+    id_status: ScheduleStatus.NOT_REALIZED,
+    student_id: 9,
+    monitor_id: 2,
+    description: '',
+  },
+  {
+    id: 5,
+    start: new Date('2023-01-20 13:00:00'),
+    end: new Date('2023-01-20 14:00:00'),
+    id_status: ScheduleStatus.CONFIRMED,
+    student_id: 7,
+    monitor_id: 2,
+    description: '',
+  },
+];

--- a/prisma/mocks/students.mock.ts
+++ b/prisma/mocks/students.mock.ts
@@ -1,0 +1,70 @@
+export const students = [
+  {
+    userData: {
+      id: 6,
+      email: 'nabson.aluno@icomp.ufam.edu.br',
+      name: 'Nabson Paiva',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 1,
+    },
+    studentData: {
+      user_id: 6,
+      description: '',
+      enrollment: '11111111',
+      course_id: 1,
+      contact_email: 'nabson.aluno@icomp.ufam.edu.br',
+    },
+  },
+  {
+    userData: {
+      id: 7,
+      email: 'marcos.aluno@icomp.ufam.edu.br',
+      name: 'Marcos Paulo',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 1,
+    },
+    studentData: {
+      user_id: 7,
+      description: '',
+      enrollment: '22222222',
+      course_id: 1,
+      contact_email: 'marcos.aluno@icomp.ufam.edu.br',
+    },
+  },
+  {
+    userData: {
+      id: 8,
+      email: 'chris.aluno@icomp.ufam.edu.br',
+      name: 'Christian Alex',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 1,
+    },
+    studentData: {
+      user_id: 8,
+      description: '',
+      enrollment: '33333333',
+      course_id: 2,
+      contact_email: 'chris.aluno@icomp.ufam.edu.br',
+    },
+  },
+  {
+    userData: {
+      id: 9,
+      email: 'fernando.aluno@icomp.ufam.edu.br',
+      name: 'Fernando Neves',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 1,
+    },
+    studentData: {
+      user_id: 9,
+      description: '',
+      enrollment: '44444444',
+      course_id: 2,
+      contact_email: 'fernando.aluno@icomp.ufam.edu.br',
+    },
+  },
+];

--- a/prisma/mocks/teachers.mock.ts
+++ b/prisma/mocks/teachers.mock.ts
@@ -1,0 +1,68 @@
+import { SubjectResponsabilityStatus } from 'src/subject/utils/subject.enum';
+
+export const teachers = [
+  {
+    userData: {
+      id: 2,
+      email: 'juan.professor@icomp.ufam.edu.br',
+      name: 'Juan Colonna',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 2,
+    },
+    responsabilities: [
+      {
+        id: 1,
+        professor_id: 2,
+        subject_id: 1,
+        id_status: SubjectResponsabilityStatus.APPROVED,
+      },
+      {
+        id: 2,
+        professor_id: 2,
+        subject_id: 2,
+        id_status: SubjectResponsabilityStatus.APPROVED,
+      },
+    ],
+  },
+  {
+    userData: {
+      id: 3,
+      email: 'andre.professor@icomp.ufam.edu.br',
+      name: 'André Carvalho',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 2,
+    },
+    responsabilities: [
+      {
+        id: 3,
+        professor_id: 3,
+        subject_id: 1,
+        id_status: SubjectResponsabilityStatus.APPROVED,
+      },
+    ],
+  },
+  {
+    userData: {
+      id: 4,
+      email: 'nakamura.professor@icomp.ufam.edu.br',
+      name: 'Eduardo Nakamura',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 2,
+    },
+    responsabilities: [],
+  },
+  {
+    userData: {
+      id: 5,
+      email: 'tayana.professor@icomp.ufam.edu.br',
+      name: 'Tayana Conte',
+      password: '$2b$10$tD2DAHmqPIoGNmYxmD.8Zu/0L6GMqUN3q0S31SPnpsvDjXvTES6.2',
+      is_verified: true,
+      type_user_id: 2,
+    },
+    responsabilities: [],
+  },
+];

--- a/prisma/populate.ts
+++ b/prisma/populate.ts
@@ -1,0 +1,139 @@
+import { PrismaClient } from '@prisma/client';
+import { coordinator } from './mocks/coordinator.mock';
+import { monitors } from './mocks/monitors.mock';
+import { schedules } from './mocks/schedules.mock';
+import { students } from './mocks/students.mock';
+import { teachers } from './mocks/teachers.mock';
+
+const prisma = new PrismaClient();
+async function main() {
+  await populateCoordinator();
+
+  await populateTeachers();
+
+  await populateStudents();
+
+  await populateMonitors();
+
+  await populateSchedules();
+}
+
+async function populateCoordinator() {
+  await prisma.user.upsert({
+    create: coordinator,
+    update: {},
+    where: { email: coordinator.email },
+  });
+
+  await prisma.coordinator.upsert({
+    create: {
+      id: coordinator.id,
+    },
+    update: {},
+    where: { id: coordinator.id },
+  });
+
+  console.log('Coordinator populated.');
+}
+
+async function populateStudents() {
+  for (const student of students) {
+    await prisma.user.upsert({
+      create: student.userData,
+      update: {},
+      where: { email: student.userData.email },
+    });
+
+    await prisma.student.upsert({
+      create: {
+        user_id: student.studentData.user_id,
+        description: student.studentData.description,
+        enrollment: student.studentData.enrollment,
+        course_id: student.studentData.course_id,
+        contact_email: student.studentData.contact_email,
+      },
+      update: {},
+      where: { user_id: student.studentData.user_id },
+    });
+  }
+
+  console.log('Students populated.');
+}
+
+async function populateTeachers() {
+  for (const teacher of teachers) {
+    await prisma.user.upsert({
+      create: teacher.userData,
+      update: {},
+      where: { email: teacher.userData.email },
+    });
+
+    await prisma.teacher.upsert({
+      create: {
+        user_id: teacher.userData.id,
+      },
+      update: {},
+      where: { user_id: teacher.userData.id },
+    });
+
+    for (const responsability of teacher.responsabilities) {
+      await prisma.subjectResponsability.upsert({
+        create: responsability,
+        update: {},
+        where: {
+          id: responsability.id,
+        },
+      });
+    }
+  }
+
+  console.log('Teachers populated.');
+}
+
+async function populateMonitors() {
+  for (const monitor of monitors) {
+    await prisma.monitor.upsert({
+      create: monitor.monitorData,
+      update: {},
+      where: {
+        id: monitor.monitorData.id,
+      },
+    });
+
+    for (const time of monitor.availableTimes) {
+      await prisma.availableTimes.upsert({
+        create: time,
+        update: {},
+        where: {
+          id: time.id,
+        },
+      });
+    }
+  }
+
+  console.log('Monitors populated.');
+}
+
+async function populateSchedules() {
+  for (const schedule of schedules) {
+    await prisma.scheduleMonitoring.upsert({
+      create: schedule,
+      update: {},
+      where: {
+        id: schedule.id,
+      },
+    });
+  }
+
+  console.log('Schedules populated.');
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });


### PR DESCRIPTION
# Descrição

[📌 Criar comando para popular banco  de dev](https://computero.atlassian.net/browse/DS-180)

Este PR: 
- Adiciona o script `populate.ts` para popular o banco de dados.
- Adiciona os comandos `make db-populate` e `make db-prune` ao Makefile. Este segundo serve para limpar todos os dados do docker e do banco local. 

# Setup

- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco local (docker).

# Cenários

## 1. Cenário A**

- [ ] Rode o comando `make db-prune` para limpar todo o seu ambiente do docker.
- [ ] Suba a API com `make build up`
- [ ] Rode o comando `make db-migrate` para aplicar as migrações do prisma ao seu banco de dados local
- [ ] Rode o comando `make db-seed` para popular as tabelas iniciais 
- [ ] Rode o comando `make db-populate` e verifique no banco de dados que as tabelas indicadas nos arquivos `*.mock.ts` foram populadas com sucesso.
