### PR TITLE
fix: Corrige o fuso horário na busca de agendamentos não finalizados

### DIFF
--- a/src/schedules/commands/list-ending-schedules.command.ts
+++ b/src/schedules/commands/list-ending-schedules.command.ts
@@ -8,12 +8,14 @@ import scheduleSelectPrismaSQL from '../utils/select-schedule.prisma-sql';
 @Injectable()
 export class ListEndingSchedulesCommand {
   constructor(private prisma: PrismaService) {}
-
   async execute(monitorUserId: number): Promise<ListEndingSchedulesResponse> {
+    const now = new Date();
+    const AMT_OFFSET = -4;
+    now.setHours(now.getHours() + AMT_OFFSET);
     const where = {
       id_status: ScheduleStatus.CONFIRMED,
       end: {
-        lte: new Date(),
+        lte: now.toISOString(),
       },
       monitor: {
         student: {


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Sistema exige que Monitor confirme realização de ajuda antes de passar da data limite do agendamento](https://computero.atlassian.net/browse/DS-203)


<!-- O que este pull request faz? -->
Comentário resumido sobre o objetivo do Pull Request
- Corrige o comando que busca os agendamentos que já deveriam ser finalizados, agora ele leva em consideração o horário de Manaus

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
- O fuso horário de Manaus não estava sendo considerado
- O que foi feito para corrigi-lo?
- Subtraído o horário com base no fuso de Manaus.

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com uma conta de estudante.
- [ ] Solicite um agendamento com um monitor
- [ ] Com uma conta de monitor aceite o agendamento

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Altere a data de finalização do agendamento para um horário que já passou (Horário local)
- [ ] Verificar se o aviso de agendamentos que precisam ser finalizados irá aparecer no front ou
- [ ] Verificar na rota GET /schedules/ending se o agendamentos irá aparecer.

## 2. Cenário B**

- [ ] Altere a data de finalização do agendamento para um horário até 4 horas depois do horário local atual 
- [ ] Verificar se o aviso de agendamentos que precisam ser finalizados **não** irá aparecer no front ou
- [ ] Verificar na rota GET /schedules/ending se o agendamentos **não** irá aparecer.
