### PR TITLE
feat: Nova rota para listar dados de monitor

### DIFF
--- a/src/monitor/commands/get-monitor.command.ts
+++ b/src/monitor/commands/get-monitor.command.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { Monitor } from '../domain/monitor';
+import { MonitorNotFoundException } from 'src/student/utils/exceptions';
+import { MonitorFactory } from '../utils/monitor.factory';
+
+@Injectable()
+export class GetMonitorCommand {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async execute(monitorId: number): Promise<Monitor> {
+    const monitor = await this.prismaService.monitor.findUnique({
+      where: {
+        id: monitorId,
+      },
+      include: {
+        responsible_professor: { include: { user: true } },
+        student: { include: { course: true, user: true } },
+        subject: { include: { course: true } },
+        AvailableTimes: true,
+        status: true,
+        MonitorSettings: {
+          select: {
+            id: true,
+            preferential_place: true,
+            is_active: true,
+          },
+          where: {
+            is_active: true,
+          },
+        },
+      },
+    });
+
+    if (!monitor) {
+      throw new MonitorNotFoundException();
+    }
+
+    return MonitorFactory.createMonitor(monitor);
+  }
+}

--- a/src/monitor/domain/monitor.ts
+++ b/src/monitor/domain/monitor.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Teacher } from 'src/user/domain/teacher';
+import { Subject } from 'src/subject/domain/subject';
+import { Student } from 'src/user/domain/student';
+
+class Availability {
+  @ApiProperty({ type: Number })
+  id: number;
+
+  @ApiProperty({ type: Number })
+  week_day: number;
+
+  @ApiProperty({ type: Date })
+  start: Date;
+
+  @ApiProperty({ type: Date })
+  end: Date;
+}
+
+class MonitorSettings {
+  @ApiProperty({ type: Number })
+  id: number;
+
+  @ApiProperty({ type: String })
+  preferentialPlace: string;
+
+  @ApiProperty({ type: Boolean })
+  isActive: boolean;
+}
+
+export class Monitor {
+  @ApiProperty({ type: Number })
+  id: number;
+
+  @ApiProperty({ type: String })
+  status: string;
+
+  @ApiProperty({ type: Date })
+  endDate: Date;
+
+  @ApiProperty({ type: Student })
+  student?: Student;
+
+  @ApiProperty({ type: Subject })
+  subject?: Subject;
+
+  @ApiProperty({ type: Teacher })
+  responsible?: Teacher;
+
+  @ApiProperty({ type: MonitorSettings })
+  monitorSettings?: MonitorSettings;
+
+  @ApiProperty({ type: [Availability] })
+  availability?: Availability[];
+}

--- a/src/monitor/monitor.module.ts
+++ b/src/monitor/monitor.module.ts
@@ -15,6 +15,7 @@ import { ListMonitorsCommand } from './commands/list-monitors.command';
 import { AcceptScheduleCommand } from './commands/accept-schedule.command';
 import { RefuseScheduledMonitoringCommand } from './commands/refuse-scheduled-monitoring.command';
 import { EndMonitoringCommand } from './commands/end-monitoring.command';
+import { GetMonitorCommand } from './commands/get-monitor.command';
 
 @Module({
   controllers: [MonitorController],
@@ -22,6 +23,7 @@ import { EndMonitoringCommand } from './commands/end-monitoring.command';
   providers: [
     AcceptScheduleCommand,
     EndMonitoringCommand,
+    GetMonitorCommand,
     ListMonitorsCommand,
     RefuseScheduledMonitoringCommand,
     MonitorService,

--- a/src/monitor/utils/monitor.factory.ts
+++ b/src/monitor/utils/monitor.factory.ts
@@ -1,0 +1,55 @@
+import { UserFactory } from 'src/user/utils/user.factory';
+import { Monitor } from '../domain/monitor';
+
+export class MonitorFactory {
+  static createMonitor(prismaMonitor): Monitor {
+    const subject = {
+      id: prismaMonitor.subject.id,
+      code: prismaMonitor.subject.code,
+      name: prismaMonitor.subject.name,
+      course: {
+        id: prismaMonitor.subject.course.id,
+        code: prismaMonitor.subject.course.code,
+        name: prismaMonitor.subject.course.name,
+      },
+    };
+
+    const responsible = {
+      id: prismaMonitor.responsible_professor.user.id,
+      name: prismaMonitor.responsible_professor.user.name,
+      email: prismaMonitor.responsible_professor.user.email,
+    };
+
+    let monitorSettings = null;
+    if (prismaMonitor.MonitorSettings.length) {
+      monitorSettings = {
+        id: prismaMonitor.MonitorSettings[0].id,
+        preferentialPlace: prismaMonitor.MonitorSettings[0].preferential_place,
+        isActive: prismaMonitor.MonitorSettings[0].is_active,
+      };
+    }
+
+    const availability = [];
+    for (const availableTime of prismaMonitor.AvailableTimes) {
+      availability.push({
+        id: availableTime.id,
+        week_day: availableTime.week_day,
+        start: availableTime.start,
+        end: availableTime.end,
+      });
+    }
+
+    const monitor: Monitor = {
+      id: prismaMonitor.id,
+      status: prismaMonitor.status.status,
+      endDate: prismaMonitor.end_date,
+      student: UserFactory.createStudent(prismaMonitor.student),
+      subject,
+      responsible,
+      monitorSettings,
+      availability,
+    };
+
+    return monitor;
+  }
+}


### PR DESCRIPTION
# Descrição

📌 [Criar rota de dados de monitoria](https://computero.atlassian.net/browse/DS-211)

Esta PR adiciona uma nova rota (`GET /monitor/:id`) para listar os dados de uma monitoria, bem como deprecia a rota `GET /availability/:monitorID`, uma vez que as informações de disponibilidades já ficarão atreladas ao monitor na nova rota.

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco local (Docker).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`

# Cenários

## 1. Cenário A**

- [ ] Acesse a rota `GET /monitor/{monitorId}`
- [ ] Faça um request com o monitor id `2`
- [ ] Verifique que as informações retornadas estão no formato indicado no card (link no começo da PR)
- [ ] Teste outros cenários de sua escolha, escolhendo diferentes ids de monitoria.