### PR TITLE
fix: Conserta regex da entrada do linkedin

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -32,7 +32,7 @@ export class Validations {
   static validateLinkedIn(linkedin: string) {
     if (linkedin.length == 0) return true;
     const re =
-      /^(https:(?:\/\/)www.linkedin.com(\/)in(\/)([\w.#&-]{5,60}))(\/)$/gm;
+      /^(http(s)?:\/\/)?([\w]+\.)?linkedin\.com\/(pub|in|profile)\/([-a-zA-Z0-9]+)\/*/gm;
     return re.test(linkedin);
   }
 


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Corrigir regex do linkedin](https://computero.atlassian.net/browse/DS-220)


<!-- O que este pull request faz? -->
Corrige regex de validação do linkedin

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
  - A regex antiga não aceitava link sem `https` e outras coisas simples
- O que foi feito para corrigi-lo?
  - Usa reges do site https://www.debugpointer.com/regex/regex-for-linkedin-profile-url

# Setup

- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Alterar linkedin

- [ ] Chamar a rota de criar aluno passando vários formatos de url de linkedin válido
- [ ] Chamar a rota de editar aluno passando vários formatos de url de linkedin válido

