### PR TITLE
feat: Adiciona monitor_settings nas rotas que trazer informações do m…

### DIFF
--- a/src/monitor/commands/list-monitors.command.ts
+++ b/src/monitor/commands/list-monitors.command.ts
@@ -57,6 +57,10 @@ export class ListMonitorsCommand {
           select: { user: { select: { name: true } } },
         },
         status: { select: { status: true } },
+        MonitorSettings: {
+          select: { id: true, preferential_place: true },
+          where: { is_active: true },
+        },
       },
       take,
       skip,

--- a/src/monitor/domain/monitor.ts
+++ b/src/monitor/domain/monitor.ts
@@ -17,7 +17,7 @@ class Availability {
   end: Date;
 }
 
-class MonitorSettings {
+export class MonitorSettings {
   @ApiProperty({ type: Number })
   id: number;
 

--- a/src/schedules/domain/schedule.ts
+++ b/src/schedules/domain/schedule.ts
@@ -3,6 +3,7 @@ import { Subject } from 'src/subject/domain/subject';
 import { User } from 'src/user/domain/user';
 import { ScheduleStatus } from '../utils/schedules.enum';
 import { Topic } from '../dto/topic.dto';
+import { MonitorSettings } from 'src/monitor/domain/monitor';
 
 class Student extends User {
   @ApiProperty({ type: String })
@@ -44,4 +45,7 @@ export class Schedule {
 
   @ApiProperty({ type: Topic })
   topic?: Topic;
+
+  @ApiProperty({ type: Topic })
+  monitorSettings?: MonitorSettings;
 }

--- a/src/schedules/utils/schedule.factory.ts
+++ b/src/schedules/utils/schedule.factory.ts
@@ -52,6 +52,14 @@ export class ScheduleFactory {
       };
     }
 
+    if (!!prismaSchedule.monitor_settings) {
+      schedule.monitorSettings = {
+        id: prismaSchedule.monitor_settings.id,
+        preferentialPlace: prismaSchedule.monitor_settings.preferential_place,
+        isActive: prismaSchedule.monitor_settings.is_active,
+      };
+    }
+
     return schedule;
   }
 }

--- a/src/schedules/utils/select-schedule.prisma-sql.ts
+++ b/src/schedules/utils/select-schedule.prisma-sql.ts
@@ -30,6 +30,9 @@ const scheduleSelectPrismaSQL = {
       name: true,
     },
   },
+  monitor_settings: {
+    select: { id: true, preferential_place: true, is_active: true },
+  },
   monitor: {
     select: {
       id: true,
@@ -48,6 +51,10 @@ const scheduleSelectPrismaSQL = {
       },
       responsible_professor: {
         select: { ...userSelect },
+      },
+      MonitorSettings: {
+        select: { id: true, preferential_place: true, is_active: true },
+        where: { is_active: true },
       },
     },
   },

--- a/src/student/commands/list-student-schedules.command.ts
+++ b/src/student/commands/list-student-schedules.command.ts
@@ -56,8 +56,28 @@ export class ListStudentSchedulesCommand {
             name: true,
           },
         },
-        monitor: { include: { student: studentInclude, subject: true } },
+        monitor: {
+          include: {
+            student: studentInclude,
+            subject: true,
+            MonitorSettings: {
+              select: {
+                id: true,
+                preferential_place: true,
+                is_active: true,
+              },
+              where: { is_active: true },
+            },
+          },
+        },
         student: studentInclude,
+        monitor_settings: {
+          select: {
+            id: true,
+            preferential_place: true,
+            is_active: true,
+          },
+        },
       },
       orderBy: {
         start: 'asc',
@@ -73,7 +93,6 @@ export class ListStudentSchedulesCommand {
         schedule['is_monitoring'] = true;
       else schedule['is_monitoring'] = false;
     });
-
     return pagination(schedules, query);
   }
 }

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -45,6 +45,10 @@ export class SubjectService {
             responsible_professor: {
               select: { user: selecUserData.select.user },
             },
+            MonitorSettings: {
+              select: { id: true, preferential_place: true },
+              where: { is_active: true },
+            },
           },
         },
       },
@@ -99,6 +103,10 @@ export class SubjectService {
                 },
               },
             },
+            MonitorSettings: {
+              select: { id: true, preferential_place: true },
+              where: { is_active: true },
+            },
           },
         },
       },
@@ -144,6 +152,10 @@ export class SubjectService {
             status: { select: { id: true, status: true } },
             responsible_professor: {
               select: { user: selecUserData.select.user },
+            },
+            MonitorSettings: {
+              select: { id: true, preferential_place: true },
+              where: { is_active: true },
             },
           },
           where: {


### PR DESCRIPTION
…onitor

# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Retornar preferência de atendimento da monitoria](https://computero.atlassian.net/browse/DS-212)


<!-- O que este pull request faz? -->
Comentário resumido sobre o objetivo do Pull Request
- Retorna os dados de preferência da monitoria nas rotas que trazem informação do monitor

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco local (dev).
- [ ] Suba a API com `make up`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Retornos

- [ ] Adicionar informações na tabela de monitor_settings. 
- [ ] Acessar as rotas 
  -  GET /subject
  - GET /subject/:id
  - GET /monitor/all
  - GET /student/schedules
- [ ] Verificar se as rotas trazem corretamente as informações de preferência de monitoria.


Observação: 
- As rotas abaixo Trazem apenas as informações que estão marcadas como ativa
  -  GET /subject
  - GET /subject/:id
  - GET /monitor/all
-  A rota `GET /student/schedules` irá trazer a informação as configurações ativas do monitor e as configurações da monitoria (a que era ativa ao marcar o agendamento)

## 2. Agendamento

- [ ] Criar agendamento com monitor que possui uma `monitor_settings` ativa
- [ ] Verificar se o campo `monitor_settings_id` do agendamento foi preenchido com o id do `monitor_settings` ativo do monitor