### PR TITLE
fix: Remove vírgula indevida

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 generator client {
-  provider = "prisma-client-js",
+  provider = "prisma-client-js"
   previewFeatures = ["interactiveTransactions"]
 }
 


### PR DESCRIPTION
# Descrição

Remove vírgula errada no esquema do prisma. Tá causando erro no `npx prisma generate`
