### PR TITLE
fix: Conserta regex do nome do usuário

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -4,8 +4,7 @@ export class Validations {
   }
 
   static validateName(name: string) {
-    const re =
-      /^([a-zA-ZáàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ']{3,}){1}(([',. -][a-zA-ZáàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ' ]{3,45}))$/gm;
+    const re = /^[a-zA-Z]+(([',. -][a-zA-Z ])?[a-zA-Z]*)*$/gm;
     return re.test(name);
   }
 


### PR DESCRIPTION
# Descrição

O usuário com nome "Jo Pereira" não tá conseguindo se cadastrar porque a regex de validação do nome exige ao menos 3 letras nas palavras do nome passado.

Muda a regex para a do site https://www.regextester.com/93648
