### PR TITLE
fix: Aceita emails com hifen

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -15,12 +15,12 @@ export class Validations {
   }
 
   static validateEmail(email: string) {
-    const re = /^([\w.]{3,20})@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/gm;
+    const re = /^([\w.-]{3,20})@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/gm;
     return re.test(email);
   }
 
   static validateEmailContact(email: string) {
-    const re = /^([\w.]{3,20})@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/gm;
+    const re = /^([\w.-]{3,20})@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/gm;
     return re.test(email);
   }
 


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Campo de e-mail não aceita hífen](https://computero.atlassian.net/browse/DS-229)


<!-- O que este pull request faz? -->
Essa PR adiciona hífen (-) ao Regex, que valida os E-mails, como caractere aceito.
- Adiciona o hífen (-) como caractere aceito aos e-mail utilizados para cadastro.

### 🐞 Em casos de bugfix

- Qual foi a causa do bug? E-mails com hífen (-) não estavam sendo aceitos no formulário de cadastro.
- O que foi feito para corrigi-lo? O caractere hífen (-) foi adicionado ao regex de validação de e-mails.

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Na rota `POST /user/student`, preencha todos os dados solicitados.
- [ ] Ainda na rota `POST /user/student`, no campo de `email` e `contact_email` adicione um e-mail válido que contenha hífen (-).
- [ ] Verifique se o Estudante foi cadastrado com sucesso.