### PR TITLE
Revert "chore: Remove validação de e-mail institucional"

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -15,7 +15,8 @@ export class Validations {
   }
 
   static validateEmail(email: string) {
-    const re = /^([\w.]{3,20})@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/gm;
+    const re =
+      /^([\w.]{3,20})@(icomp\.ufam\.edu\.br|ufam\.edu\.br|super\.ufam\.edu\.br)$/gm;
     return re.test(email);
   }
 


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Ativar a validação de email](https://computero.atlassian.net/jira/software/projects/DS/boards/8?selectedIssue=DS-225)

Adiciona a validação de e-mail que permite que apenas e-mail com domínio icomp, super ou ufam se cadastrem no sistema.

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`

# Cenários

## 1. Cadastro

- [ ] Faça uma requisição para rota `POST /user/student` passando o body abaixo:
  ```json
  {
    "email": "meuemail@icomp.ufam.com.br",
    "name": "Fulano Tal",
    "password": "12345678",
    "confirm_password": "12345678",
    "description": "",
    "enrollment": "45645643",
    "course_id": 1,
    "contact_email": "",
    "whatsapp": "",
    "linkedin": ""
  }
  ```
- [ ] Verifique que a rota retornou 204 e o usuário foi criado
