### PR TITLE
feat: Add monitoria ativa ao token se existir uma

### DIFF
--- a/src/auth/interfaces/jwt-user.interface.ts
+++ b/src/auth/interfaces/jwt-user.interface.ts
@@ -7,6 +7,14 @@ export interface JWTUser {
     id: number;
     type: Role;
   };
+  monitor?: {
+    id: number;
+    id_status: number;
+    end_date: Date;
+    responsible_professor_id: number;
+    student_id: number;
+    subject_id: number;
+  };
   type_user_id: number;
   iat?: number;
   exp?: number;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -25,6 +25,7 @@ import {
   PersonalDataInPasswordException,
   UserNotFoundException,
 } from './utils/exceptions';
+import { MonitorStatus } from 'src/monitor/utils/monitor.enum';
 
 @Injectable()
 export class UserService {
@@ -192,6 +193,27 @@ export class UserService {
       },
       orderBy: {
         created_at: 'asc',
+      },
+    });
+  }
+
+  async findOneByEmailWithOnGoingMonitor(email: string) {
+    return this.prisma.user.findUnique({
+      where: { email },
+      include: {
+        student: {
+          include: {
+            Monitor: {
+              where: {
+                id_status: {
+                  in: [MonitorStatus.APPROVED, MonitorStatus.AVAILABLE],
+                },
+                end_date: null,
+              },
+            },
+          },
+        },
+        type_user: true,
       },
     });
   }


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 título do card](link-do-card)

Para mostrar ou não o botão de Monitoria na sidebar no front, precisamos retornar a monitoria ativa (status aprovada ou disponível) do aluno no token de autenticação, caso exista uma.

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco local.
- [ ] Suba a API com `make up`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Login com usuário monitor

- [ ] Faça login com a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`
- [ ] Decodifique o token retornado no site https://jwt.io/
- [ ] Verifique que o data do token possui a monitoria ativa do aluno no campo `monitor`

## 2. Login com usuário NÃO monitor

- [ ] Faça login com a conta `tayana.professor@icomp.ufam.edu.br` | `12345678`
- [ ] Decodifique o token retornado no site https://jwt.io/
- [ ] Verifique que o data do token possui não monitoria ativa do aluno no campo `monitor`
