### PR TITLE
fix: correção do armazenamento de cache no servidor apache

### DIFF
--- a/.infra/apache2.config
+++ b/.infra/apache2.config
@@ -18,4 +18,10 @@
 
   FallbackResource /index.html
   RewriteEngine on
+
+  # Definindo cabeçalhos de cache para arquivos estáticos - 4 horas
+  <Directory /var/www/html>
+    Header set Cache-Control "max-age=14400, public"
+  </Directory>
+
 </VirtualHost>


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
📌[ Problema de limpar cache para acessar telas - DS 230](https://computero.atlassian.net/browse/DS-230?atlOrigin=eyJpIjoiZTM2YjA0YjE2MDlmNGY4MDgyYmI4OTA2NDc0MzVmNDAiLCJwIjoiaiJ9)

<!-- O que este pull request faz? -->

 Seta configuração de tempo de expiração de cache no servidor do apache.

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
  O navegador estava armazenando em cache uma versão anterior do sistema, resultando em um carregamento infinito sempre que um usuário com o cache da versão anterior do sistema tentava acessar qualquer página.
  
- O que foi feito para corrigi-lo?
    Adição de tempo, 4 horas, de expiração do cache no arquivo de configuração do apache: .infra/apache2.config

# Setup
- [ ] Encontre um navegador que esteja apresentando esse problema para teste posteriormente.
- [ ] Façao merge da branch para a staging
- [ ] Faça o Deploy da staging

# Cenários

<!-- Ao acessar qualquer página do sistema que esteja armazenada em cache na versão anterior, a página deve ser exibida, e as respectivas políticas de aceitação de cada cenário devem ser aplicadas. -->

## 1. Cenário A**

### Resultado Válido
- [ ] Acessar qualquer página do sistema em produção, com o cache na versão que estava com o  bug.
- [ ] Verificar se a página é carregada normalmente. 
