### PR TITLE
fix: nome do monitor na notificacao de cancelamento

### DIFF
--- a/src/monitor/commands/refuse-scheduled-monitoring.command.ts
+++ b/src/monitor/commands/refuse-scheduled-monitoring.command.ts
@@ -21,7 +21,7 @@ export class RefuseScheduledMonitoringCommand {
       include: {
         monitor: {
           include: {
-            MonitorSettings: { where: { is_active: true } }, 
+            MonitorSettings: { where: { is_active: true } },
             student: { include: { user: true } },
           },
         },

--- a/src/monitor/commands/refuse-scheduled-monitoring.command.ts
+++ b/src/monitor/commands/refuse-scheduled-monitoring.command.ts
@@ -22,7 +22,7 @@ export class RefuseScheduledMonitoringCommand {
         monitor: {
           include: {
             MonitorSettings: { where: { is_active: true } }, 
-            student: { include: { user: true } }
+            student: { include: { user: true } },
           },
         },
         student: {

--- a/src/monitor/commands/refuse-scheduled-monitoring.command.ts
+++ b/src/monitor/commands/refuse-scheduled-monitoring.command.ts
@@ -20,7 +20,7 @@ export class RefuseScheduledMonitoringCommand {
       where: { id: scheduleId },
       include: {
         monitor: {
-          include: { MonitorSettings: { where: { is_active: true } } },
+          include: {  MonitorSettings: { where: { is_active: true } }, student: { include: { user: true } } },
         },
         student: {
           include: { user: true },
@@ -52,7 +52,7 @@ export class RefuseScheduledMonitoringCommand {
     await this.emailService.sendEmailRefuseScheduledMonitoring(
       email,
       'Cancelado',
-      schedule.student.user.name,
+      schedule.monitor.student.user.name,
       schedule.start.toLocaleDateString('pt-BR'),
       schedule.start.toLocaleTimeString('pt-BR').slice(0, 5),
       schedule.end.toLocaleTimeString('pt-BR').slice(0, 5),

--- a/src/monitor/commands/refuse-scheduled-monitoring.command.ts
+++ b/src/monitor/commands/refuse-scheduled-monitoring.command.ts
@@ -20,7 +20,10 @@ export class RefuseScheduledMonitoringCommand {
       where: { id: scheduleId },
       include: {
         monitor: {
-          include: {  MonitorSettings: { where: { is_active: true } }, student: { include: { user: true } } },
+          include: {
+            MonitorSettings: { where: { is_active: true } }, 
+            student: { include: { user: true } }
+          },
         },
         student: {
           include: { user: true },


### PR DESCRIPTION
# Descrição

[📌 Nome do Monitor na notificação de Cancelamento](https://computero.atlassian.net/jira/software/projects/DS/boards/8?selectedIssue=DS-261)

Esta PR adiciona o Nome do Monitor no E-mail de notificação de Cancelamento de solicitação de monitoria. 

### 🐞 Em casos de bugfix

- Qual foi a causa do bug? Quando o monitor recusava uma solicitação de monitoria o e-mail de notificação que é enviado para o Estudante apresentava o nome incorreto no campo `Monitor`.
- O que foi feito para corrigi-lo? O nome correto do monitor foi passado para o template de e-mail de cancelamento.

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco local (docker) 
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `fernando.aluno@icomp.ufam.edu.br` | `12345678`

# Cenários

## 1. Cenário A**

- [ ] No banco de dados, altere os campos `contact_email` do estudante e do monitor alvo para serem e-mails aos quais você tem acesso.
- [ ] Na rota `POST /student/{monitor_id}/schedule`, solicite dois agendamentos para o monitor.
- [ ] Na rota `POST /monitor/accept/scheduled-monitoring/{scheduleId}`, aceite um dos agendamentos
- [ ] Verifique que a notificação por e-mail foi enviada com sucesso para o estudante, com o campo `Monitor` com o nome correto do Monitor.
- [ ] Na rota `POST /monitor/refuse/scheduled-monitoring/{scheduled_monitoring_id}`, recuse o outro agendamento
- [ ] Verifique que a notificação por e-mail foi enviada com sucesso para o estudante, com o campo `Monitor` com o nome correto do Monitor.