### PR TITLE
test: Testes unitários do módulo 'student'

### DIFF
--- a/__tests__/__utils__/factories/student.prisma.factory.ts
+++ b/__tests__/__utils__/factories/student.prisma.factory.ts
@@ -1,0 +1,128 @@
+export class CreatePrismaFactory {
+  static build(props) {
+    return {
+      user_id: 1,
+      description: 'Create a New Strudent - Teste',
+      enrollment: '22222222',
+      course_id: 2,
+      contact_email: 'estudante@icomp.ufam.edu.br',
+      whatsapp: '92912345678',
+      linkedin: 'linkedin.com/in/estudante-ufam/',
+      ...props,
+    };
+  }
+}
+
+export class FindStudentFactory {
+  static build(props) {
+    return {
+      user_id: 1,
+      description: '',
+      enrollment: '22222222',
+      course_id: 1,
+      course: {
+        id: 1,
+        name: 'Engenharia de Software',
+      },
+      contact_email: 'estudante@icomp.ufam.edu.br',
+      whatsapp: null,
+      linkedin: null,
+      user: {
+        id: 7,
+        email: 'estudante@icomp.ufam.edu.br',
+        name: 'Fulando de Menezes',
+        is_verified: true,
+        type_user_id: 1,
+        updated_at: '2023-09-06T17:45:58.769Z',
+        created_at: '2023-09-06T17:45:58.769Z',
+      },
+      ...props,
+    };
+  }
+}
+
+export class GetMonitorAvailability {
+  static build(props) {
+    return {
+      id: 2,
+      status: 'Disponível',
+      endDate: null,
+      student: {
+        id: 6,
+        name: 'Estudante',
+        email: 'estudante@icomp.ufam.edu.br',
+        contactEmail: 'estudante@icomp.ufam.edu.br',
+        description: '',
+        enrollment: '22222222',
+        whatsapp: null,
+        linkedin: null,
+        courseId: 1,
+        course: {
+          id: 1,
+          name: 'Engenharia de Software',
+        },
+      },
+      subject: {
+        id: 2,
+        code: 'ICC015',
+        name: 'Desafios De Programação I',
+        course: {
+          id: 2,
+          code: 'IE08',
+          name: 'Ciência da Computação',
+        },
+      },
+      responsible: {
+        id: 2,
+        name: 'Professor',
+        email: 'professor@icomp.ufam.edu.br',
+      },
+      monitorSettings: null,
+      availability: [
+        {
+          id: 1,
+          week_day: 0,
+          start: '00:00',
+          end: '23:00',
+        },
+        {
+          id: 2,
+          week_day: 1,
+          start: '00:00',
+          end: '23:00',
+        },
+        {
+          id: 3,
+          week_day: 2,
+          start: '00:00',
+          end: '23:00',
+        },
+        {
+          id: 4,
+          week_day: 3,
+          start: '00:00',
+          end: '23:00',
+        },
+        {
+          id: 5,
+          week_day: 4,
+          start: '00:00',
+          end: '23:00',
+        },
+        {
+          id: 6,
+          week_day: 5,
+          start: '00:00',
+          end: '23:00',
+        },
+        {
+          id: 7,
+          week_day: 6,
+          start: '00:00',
+          end: '23:00',
+        },
+      ],
+      ...props,
+    };
+  }
+}

--- a/__tests__/modules/student/commands/create-student.command.mock.ts
+++ b/__tests__/modules/student/commands/create-student.command.mock.ts
@@ -1,0 +1,20 @@
+export const prismaServiceMock = {
+  student: {
+    create: jest.fn(),
+  },
+};
+
+export const createStudentData = (
+  userId: number,
+  enrollment: string,
+  courseId: number,
+  contactEmail: string,
+) => ({
+  user_id: userId,
+  description: 'Create a New Strudent - Teste',
+  enrollment: enrollment,
+  course_id: courseId,
+  contact_email: contactEmail,
+  whatsapp: '92912345678',
+  linkedin: 'linkedin.com/in/estudante-ufam/',
+});

--- a/__tests__/modules/student/commands/create-student.command.spec.ts
+++ b/__tests__/modules/student/commands/create-student.command.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/database/prisma.service';
+import { CreateStudentCommand } from 'src/student/commands/create-student.command';
+import {
+  prismaServiceMock,
+  createStudentData,
+} from './create-student.command.mock';
+import { CreatePrismaFactory } from '__tests__/__utils__/factories/student.prisma.factory';
+import { StudentDTO } from 'src/student/dto/student.dto';
+
+describe('Test CreateStudentCommand', () => {
+  let createScheduleCommand: CreateStudentCommand;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateStudentCommand,
+        {
+          provide: PrismaService,
+          useValue: prismaServiceMock,
+        },
+      ],
+    }).compile();
+
+    createScheduleCommand =
+      module.get<CreateStudentCommand>(CreateStudentCommand);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a new student successfully', async () => {
+    // GIVEN
+    const userId = 1;
+    const enrollment = '22222222';
+    const courseId = 2;
+    const contactEmail = 'estudante@icomp.ufam.edu.br';
+
+    const dataNewStudent: StudentDTO = createStudentData(
+      userId,
+      enrollment,
+      courseId,
+      contactEmail,
+    );
+    const dataReturnNewStudent = CreatePrismaFactory.build(dataNewStudent);
+    prismaServiceMock.student.create.mockReturnValueOnce(dataReturnNewStudent);
+
+    // WHEN
+    const dataStudentCreated = await createScheduleCommand.execute(
+      dataNewStudent,
+    );
+
+    // THEN
+    expect(prismaServiceMock.student.create).toBeCalledWith({
+      data: dataNewStudent,
+    });
+    expect(dataStudentCreated).toBe(dataReturnNewStudent);
+  });
+});

--- a/__tests__/modules/student/commands/find-enrollment.command.mock.ts
+++ b/__tests__/modules/student/commands/find-enrollment.command.mock.ts
@@ -1,0 +1,5 @@
+export const prismaServiceMock = {
+  student: {
+    findFirst: jest.fn(),
+  },
+};

--- a/__tests__/modules/student/commands/find-enrollment.command.spec.ts
+++ b/__tests__/modules/student/commands/find-enrollment.command.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/database/prisma.service';
+import { FindEnrollmentCommand } from 'src/student/commands/find-enrollment.command';
+import { prismaServiceMock } from './find-enrollment.command.mock';
+import { FindStudentFactory } from '__tests__/__utils__/factories/student.prisma.factory';
+
+describe('Test FindEnrollmentCommand', () => {
+  let findEnrollmentCommand: FindEnrollmentCommand;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindEnrollmentCommand,
+        {
+          provide: PrismaService,
+          useValue: prismaServiceMock,
+        },
+      ],
+    }).compile();
+
+    findEnrollmentCommand = module.get<FindEnrollmentCommand>(
+      FindEnrollmentCommand,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should find a student by enrollment successfully', async () => {
+    // GIVEN
+    const dataStudentByEnrollment = FindStudentFactory.build({});
+    prismaServiceMock.student.findFirst.mockReturnValueOnce(
+      dataStudentByEnrollment,
+    );
+
+    const enrollment = dataStudentByEnrollment.enrollment;
+
+    // WHEN
+    const dataReturnStudent = await findEnrollmentCommand.execute(enrollment);
+
+    // THEN
+    expect(prismaServiceMock.student.findFirst).toBeCalledWith({
+      where: { enrollment: enrollment },
+    });
+    expect(dataReturnStudent).toBe(dataStudentByEnrollment);
+  });
+});

--- a/__tests__/modules/student/commands/find-one-by-id.command.mock.ts
+++ b/__tests__/modules/student/commands/find-one-by-id.command.mock.ts
@@ -1,0 +1,5 @@
+export const prismaServiceMock = {
+  student: {
+    findUnique: jest.fn(),
+  },
+};

--- a/__tests__/modules/student/commands/find-one-by-id.command.spec.ts
+++ b/__tests__/modules/student/commands/find-one-by-id.command.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/database/prisma.service';
+import { FindOneByIdCommand } from 'src/student/commands/find-one-by-id.command';
+import { prismaServiceMock } from './find-one-by-id.command.mock';
+import { FindStudentFactory } from '__tests__/__utils__/factories/student.prisma.factory';
+
+describe('Test FindOneByIdCommand', () => {
+  let findOneByIdCommand: FindOneByIdCommand;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindOneByIdCommand,
+        {
+          provide: PrismaService,
+          useValue: prismaServiceMock,
+        },
+      ],
+    }).compile();
+
+    findOneByIdCommand = module.get<FindOneByIdCommand>(FindOneByIdCommand);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should find a student by user_id successfully', async () => {
+    // GIVEN
+    const dataStudentByUserId = FindStudentFactory.build({});
+    prismaServiceMock.student.findUnique.mockReturnValueOnce(
+      dataStudentByUserId,
+    );
+
+    const userId = dataStudentByUserId.user_id;
+
+    // WHEN
+    const dataReturnStudent = await findOneByIdCommand.execute(userId);
+
+    // THEN
+    expect(prismaServiceMock.student.findUnique).toBeCalledWith({
+      where: { user_id: userId },
+    });
+    expect(dataReturnStudent).toBe(dataStudentByUserId);
+  });
+});

--- a/__tests__/modules/student/commands/get-monitor-availability.command.mock.ts
+++ b/__tests__/modules/student/commands/get-monitor-availability.command.mock.ts
@@ -1,0 +1,10 @@
+export const prismaServiceMock = {
+  availableTimes: {
+    findMany: jest.fn(),
+  },
+};
+
+export const getMonitorAvailabilityExpectedCall = (monitor_id: number) => ({
+  where: { monitor_id },
+  orderBy: { week_day: 'asc' },
+});

--- a/__tests__/modules/student/commands/get-monitor-availability.command.spec.ts
+++ b/__tests__/modules/student/commands/get-monitor-availability.command.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/database/prisma.service';
+import { GetMonitorAvailabilityCommand } from 'src/student/commands/get-monitor-availability.command';
+import {
+  prismaServiceMock,
+  getMonitorAvailabilityExpectedCall,
+} from './get-monitor-availability.command.mock';
+import { GetMonitorAvailability } from '__tests__/__utils__/factories/student.prisma.factory';
+
+describe('Test GetMonitorAvailabilityCommand', () => {
+  let getMonitorAvailabilityCommand: GetMonitorAvailabilityCommand;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetMonitorAvailabilityCommand,
+        {
+          provide: PrismaService,
+          useValue: prismaServiceMock,
+        },
+      ],
+    }).compile();
+
+    getMonitorAvailabilityCommand = module.get<GetMonitorAvailabilityCommand>(
+      GetMonitorAvailabilityCommand,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should find monitor availability by monitor_id successfully', async () => {
+    // GIVEN
+    const dataMonitorAvailability = GetMonitorAvailability.build({});
+    prismaServiceMock.availableTimes.findMany.mockReturnValueOnce(
+      dataMonitorAvailability,
+    );
+
+    const monitorId = dataMonitorAvailability.id;
+
+    // WHEN
+    const dataReturnMonitor = await getMonitorAvailabilityCommand.execute(
+      monitorId,
+    );
+
+    // THEN
+    expect(prismaServiceMock.availableTimes.findMany).toBeCalledWith(
+      getMonitorAvailabilityExpectedCall(monitorId),
+    );
+    expect(dataReturnMonitor).toBe(dataMonitorAvailability);
+  });
+});


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Criar testes do módulo student](https://computero.atlassian.net/browse/DS-246)

- Configura execução dos testes com jest
- Centraliza testes na pasta `__tests__`
- Cria testes unitários do Módulo `student`
- Foi desenvolvido os testes unitários dos seguintes commands do módulo student:

    - `create-student.command`
    - `find-enrollment.command`
    - `find-one-by-id.command`
    - `get-monitor-availability.command`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Execução dos testes localmente

- [ ] Execute o comando `npm run test` e verifique que todos os testes estão passando.

