### PR TITLE
feat: Cria rota para cancelar e criar matricula

### DIFF
--- a/src/subject/commands/cancel-subject-enrollment.command.ts
+++ b/src/subject/commands/cancel-subject-enrollment.command.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { SubjectService } from '../subject.service';
+import { StudentNotEnrolledException } from '../utils/exceptions';
+
+@Injectable()
+export class CancelSubjectEnrollmentCommand {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly subjectService: SubjectService,
+  ) {}
+
+  async execute(subjectId: number, studentId: number): Promise<void> {
+    const enrollment = await this.prisma.subjectEnrollment.findFirst({
+      where: {
+        student_id: studentId,
+        subject_id: subjectId,
+        canceled_at: null,
+      },
+    });
+
+    if (!enrollment) {
+      throw new StudentNotEnrolledException();
+    }
+
+    await this.prisma.subjectEnrollment.update({
+      data: { canceled_at: new Date() },
+      where: { id: enrollment.id },
+    });
+  }
+}

--- a/src/subject/commands/create-subject-enrollment.command.ts
+++ b/src/subject/commands/create-subject-enrollment.command.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { SubjectService } from '../subject.service';
+import { StudentAlreadyEnrolledException } from '../utils/exceptions';
+import { Enrollment } from '../dto/enrollment.dto';
+
+@Injectable()
+export class CreateSubjectEnrollmentCommand {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly subjectService: SubjectService,
+  ) {}
+
+  async execute(subjectId: number, studentId: number): Promise<Enrollment> {
+    const enrollment = await this.prisma.subjectEnrollment.findFirst({
+      where: {
+        student_id: studentId,
+        subject_id: subjectId,
+        canceled_at: null,
+      },
+    });
+
+    if (enrollment) {
+      throw new StudentAlreadyEnrolledException();
+    }
+
+    const subjectEnrollment = {
+      student_id: studentId,
+      subject_id: subjectId,
+    };
+
+    return await this.prisma.subjectEnrollment.create({
+      data: subjectEnrollment,
+    });
+  }
+}

--- a/src/subject/dto/enrollment.dto.ts
+++ b/src/subject/dto/enrollment.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Enrollment {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  student_id: number;
+
+  @ApiProperty()
+  subject_id: number;
+
+  @ApiProperty()
+  created_at: Date;
+
+  @ApiProperty()
+  updated_at: Date;
+
+  @ApiProperty()
+  canceled_at?: Date;
+}

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -1,12 +1,15 @@
 import {
+  BadRequestException,
+  ConflictException,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
-  BadRequestException,
   NotFoundException,
   Param,
   Patch,
+  Post,
   PreconditionFailedException,
   Query,
   Req,
@@ -14,28 +17,34 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { SubjectQueryDto } from './dto/subject-query.dto';
-import { IResponsePaginate } from 'src/common/interfaces/pagination.interface';
-import { SubjectService } from './subject.service';
-import { JWTUser } from 'src/auth/interfaces/jwt-user.interface';
-import { EndResponsabilityCommand } from './commands/end-responsability-command';
-import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { Request } from 'express';
 import { Roles } from 'src/auth/decorators/roles.decorator';
 import { Role } from 'src/auth/enums/role.enum';
-import { Request } from 'express';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { JWTUser } from 'src/auth/interfaces/jwt-user.interface';
+import { IResponsePaginate } from 'src/common/interfaces/pagination.interface';
+import { EndResponsabilityCommand } from './commands/end-responsability-command';
+import { SubjectQueryDto } from './dto/subject-query.dto';
+import { SubjectService } from './subject.service';
 import {
   AlreadyFinishedException,
   BlockingMonitorsException,
   ResponsabilityNotFoundException,
+  StudentAlreadyEnrolledException,
+  StudentNotEnrolledException,
   UserNotStudentException,
 } from './utils/exceptions';
 
+import { CancelSubjectEnrollmentCommand } from './commands/cancel-subject-enrollment.command';
+import { CreateSubjectEnrollmentCommand } from './commands/create-subject-enrollment.command';
 @Controller('subject')
 @ApiTags('Subjects')
 export class SubjectController {
   constructor(
     private readonly subjectService: SubjectService,
     private readonly endResponsabilityCommand: EndResponsabilityCommand,
+    private readonly createSubjectEnrollmentCommand: CreateSubjectEnrollmentCommand,
+    private readonly cancelSubjectEnrollmentCommand: CancelSubjectEnrollmentCommand,
     private jwtService: JwtService,
   ) {}
 
@@ -96,6 +105,52 @@ export class SubjectController {
         error instanceof BlockingMonitorsException
       ) {
         throw new PreconditionFailedException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Roles(Role.Student)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Cria uma matrícula do aluno logado na disciplina passada',
+  })
+  @Post(':id/enroll')
+  async createSubjectEnrollment(@Req() req: Request, @Param('id') id: number) {
+    try {
+      const token = req.headers.authorization.toString().replace('Bearer ', '');
+      const user = this.jwtService.decode(token) as JWTUser;
+
+      return await this.createSubjectEnrollmentCommand.execute(id, user.sub);
+    } catch (error) {
+      if (error instanceof StudentAlreadyEnrolledException) {
+        throw new ConflictException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Roles(Role.Student)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Cancela a matrícula do aluno logado na disciplina passada',
+  })
+  @Delete(':id/enroll')
+  async cancelSubjectEnrollment(@Req() req: Request, @Param('id') id: number) {
+    try {
+      const token = req.headers.authorization.toString().replace('Bearer ', '');
+      const user = this.jwtService.decode(token) as JWTUser;
+
+      return await this.cancelSubjectEnrollmentCommand.execute(id, user.sub);
+    } catch (error) {
+      if (error instanceof StudentNotEnrolledException) {
+        throw new NotFoundException(error.message);
       }
 
       throw error;

--- a/src/subject/subject.module.ts
+++ b/src/subject/subject.module.ts
@@ -1,14 +1,23 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
-import { SubjectService } from './subject.service';
-import { SubjectController } from './subject.controller';
+import { JwtModule, JwtService } from '@nestjs/jwt';
 import { PrismaService } from 'src/database/prisma.service';
+import { CancelSubjectEnrollmentCommand } from './commands/cancel-subject-enrollment.command';
+import { CreateSubjectEnrollmentCommand } from './commands/create-subject-enrollment.command';
 import { EndResponsabilityCommand } from './commands/end-responsability-command';
+import { SubjectController } from './subject.controller';
+import { SubjectService } from './subject.service';
 
 @Module({
   controllers: [SubjectController],
-  providers: [SubjectService, EndResponsabilityCommand, PrismaService],
   imports: [JwtModule],
+  providers: [
+    SubjectService,
+    EndResponsabilityCommand,
+    CreateSubjectEnrollmentCommand,
+    CancelSubjectEnrollmentCommand,
+    PrismaService,
+    JwtService,
+  ],
   exports: [SubjectService],
 })
 export class SubjectModule {}

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { UserNotStudentException } from 'src/subject/utils/exceptions';
 import { Subject } from '@prisma/client';
-import { SubjectQueryDto } from './dto/subject-query.dto';
 import { Role } from 'src/auth/enums/role.enum';
 import { IResponsePaginate } from 'src/common/interfaces/pagination.interface';
 import { pagination } from 'src/common/pagination';
 import { PrismaService } from 'src/database/prisma.service';
 import { MonitorStatus } from 'src/monitor/utils/monitor.enum';
+import { UserNotStudentException } from 'src/subject/utils/exceptions';
+import { SubjectQueryDto } from './dto/subject-query.dto';
 
 @Injectable()
 export class SubjectService {
@@ -22,6 +22,7 @@ export class SubjectService {
     const data = await this.prisma.subject.findFirst({
       where: { id: id },
       include: {
+        studentsEnrolled: {},
         SubjectResponsability: {
           select: {
             id: true,

--- a/src/subject/utils/exceptions.ts
+++ b/src/subject/utils/exceptions.ts
@@ -12,6 +12,20 @@ export class SubjectNotFoundException extends Error {
   }
 }
 
+export class StudentAlreadyEnrolledException extends Error {
+  constructor() {
+    super();
+    this.message = 'Aluno(a) já matriculado(a) na disciplina.';
+  }
+}
+
+export class StudentNotEnrolledException extends Error {
+  constructor() {
+    super();
+    this.message = 'Aluno(a) não está matriculado(a) na disciplina.';
+  }
+}
+
 export class AlreadyFinishedException extends Error {
   constructor() {
     super();


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 [DS-271] Criar rotas de matricular e desmatricular]((https://computero.atlassian.net/browse/DS-271))


<!-- O que este pull request faz? -->
Comentário resumido sobre o objetivo do Pull Request
- Cria rotas de matricular e desmatricular aluno

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Entre no swagger e tente executar as rotas de criar e deletar matricula (`subject/{id}/enrollment`)
- [ ] Verifique se o resultado de ambas foi uma excesão de token invalido
- [ ] Logue como um professor ou coordenador e tente executar mais uma vez as duas rotas
- [ ] Verifique se o resultado de ambas foi uma excesão de papel
- [ ] Logue como aluno e tentar executar as rotas com uma matéria não existente
- [ ] Verifique se o resultado de ambas foi uma excesão de materia não existente
- [ ] Execute a rota de criar matricula com um id de disciplina existente
- [ ] Verifique se o resultado foi o objeto de retorno da criação da matricula
- [ ] Tente executar novamente na mesma disciplina e verifique se o resultado foi uma excesão de aluno já matriculado
- [ ] Execute a rota de cancelar matricula em uma disciplina que o usuário não é aluno
- [ ] Verifique se o resultado foi uma excesão de aluno não matriculado
- [ ] Execute a rota passando o id de uma disciplina que o usuario está matriculado
- [ ] Verifique se o campo `canceled_at` no banco foi modificado para a data atual
