### PR TITLE
fix: Considerando o campo 'canceled_at'

### DIFF
--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -76,7 +76,10 @@ export class SubjectService {
     data.Monitor = approved_Monitores;
 
     const subjectsEnrollments = await this.prisma.subjectEnrollment.findMany({
-      where: { student_id: userId },
+      where: {
+        student_id: userId,
+        canceled_at: null,
+      },
     });
 
     data['isStudentEnrolled'] = false;
@@ -198,6 +201,9 @@ export class SubjectService {
               some: {
                 student_id: {
                   equals: userId,
+                },
+                canceled_at: {
+                  equals: null,
                 },
               },
             }


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Rota de disciplinas matriculadas](https://computero.atlassian.net/browse/DS-272)

### 🐞 Em casos de bugfix

- Qual foi a causa do bug? Ao realizar uma consulta no banco de dados na tabela `subject_enrrollment` não estava sendo considerado que o campo `canceled_at` também deve ser `null`
- O que foi feito para corrigi-lo? Na query de consulta do banco de dado foi adicionado na `where`  a clausula `canceled_at: null`

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`

## 1. Cenário A**

- [ ] Faça login com a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`
- [ ] Na rota `GET /subject` set o campo `onlyEnrollments` com `true`
- [ ] A rota deve retorna todos as diciplinas que o aluno logado estiver matriculado (que o campo `canceled_at` esteja nulo)
- [ ] Todas as disciplinas retornadas devem ter o campo `isStudentEnrolled` com `true`

## 1. Cenário B**

- [ ] Faça login com a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`
- [ ] Na rota `GET /subject` set o campo `onlyEnrollments` com `false` ou `--`
- [ ] A rota deve retorna todos as diciplinas presente no Banco de dados
- [ ] Todas as disciplinas retornadas devem ter o campo `isStudentEnrolled`
- [ ] Caso o aluno logado esteja matriculado (que o campo `canceled_at` esteja nulo) em alguma das disciplinas  o campo `isStudentEnrolled` deve estar com `true`
- [ ] Nas disciplinas que o aluno não esteja matriculado o campo `isStudentEnrolled` deve estar com `false`

## 2. Cenário C**

- [ ] Faça login com a conta `juan.professor@icomp.ufam.edu.br` | `12345678`
- [ ] Na rota `GET /subject` set o campo `onlyEnrollments` com `true`
- [ ] A rota deve retornar  `400 - usuário logado não é um aluno`

## 1. Cenário D**

- [ ] Faça login com a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`
- [ ] Na rota `GET /subject/:id` busque por alguma disciplina
- [ ] Caso o aluno logado esteja matriculado (que o campo `canceled_at` esteja nulo) na disciplina em questão o campo `isStudentEnrolled` deve estar com `true`
- [ ] Caso o aluno logado  não esteja matriculado o campo `isStudentEnrolled` deve estar com `false`
