### PR TITLE
fix: Conserta regras nas rotas de matrícula

### DIFF
--- a/src/subject/commands/cancel-subject-enrollment.command.ts
+++ b/src/subject/commands/cancel-subject-enrollment.command.ts
@@ -1,16 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
-import { SubjectService } from '../subject.service';
-import { StudentNotEnrolledException } from '../utils/exceptions';
+import {
+  StudentNotEnrolledException,
+  SubjectNotFoundException,
+} from '../utils/exceptions';
 
 @Injectable()
 export class CancelSubjectEnrollmentCommand {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly subjectService: SubjectService,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async execute(subjectId: number, studentId: number): Promise<void> {
+    const subject = await this.prisma.subject.findFirst({
+      where: { id: subjectId },
+    });
+    if (!subject) {
+      throw new SubjectNotFoundException();
+    }
+
     const enrollment = await this.prisma.subjectEnrollment.findFirst({
       where: {
         student_id: studentId,

--- a/src/subject/commands/create-subject-enrollment.command.ts
+++ b/src/subject/commands/create-subject-enrollment.command.ts
@@ -1,17 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
-import { SubjectService } from '../subject.service';
-import { StudentAlreadyEnrolledException } from '../utils/exceptions';
+import {
+  StudentAlreadyEnrolledException,
+  SubjectNotFoundException,
+} from '../utils/exceptions';
 import { Enrollment } from '../dto/enrollment.dto';
 
 @Injectable()
 export class CreateSubjectEnrollmentCommand {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly subjectService: SubjectService,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async execute(subjectId: number, studentId: number): Promise<Enrollment> {
+    const subject = await this.prisma.subject.findFirst({
+      where: { id: subjectId },
+    });
+    if (!subject) {
+      throw new SubjectNotFoundException();
+    }
+
     const enrollment = await this.prisma.subjectEnrollment.findFirst({
       where: {
         student_id: studentId,

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -32,6 +32,7 @@ import {
   ResponsabilityNotFoundException,
   StudentAlreadyEnrolledException,
   StudentNotEnrolledException,
+  SubjectNotFoundException,
   UserNotStudentException,
 } from './utils/exceptions';
 
@@ -130,6 +131,10 @@ export class SubjectController {
         throw new ConflictException(error.message);
       }
 
+      if (error instanceof SubjectNotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+
       throw error;
     }
   }
@@ -150,6 +155,10 @@ export class SubjectController {
       return await this.cancelSubjectEnrollmentCommand.execute(id, user.sub);
     } catch (error) {
       if (error instanceof StudentNotEnrolledException) {
+        throw new PreconditionFailedException(error.message);
+      }
+
+      if (error instanceof SubjectNotFoundException) {
         throw new NotFoundException(error.message);
       }
 

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -31,6 +31,7 @@ import {
   BlockingMonitorsException,
   ResponsabilityNotFoundException,
   StudentAlreadyEnrolledException,
+  StudentMonitorException,
   StudentNotEnrolledException,
   SubjectNotFoundException,
   UserNotStudentException,
@@ -129,6 +130,10 @@ export class SubjectController {
     } catch (error) {
       if (error instanceof StudentAlreadyEnrolledException) {
         throw new ConflictException(error.message);
+      }
+
+      if (error instanceof StudentMonitorException) {
+        throw new PreconditionFailedException();
       }
 
       if (error instanceof SubjectNotFoundException) {

--- a/src/subject/utils/exceptions.ts
+++ b/src/subject/utils/exceptions.ts
@@ -19,6 +19,13 @@ export class StudentAlreadyEnrolledException extends Error {
   }
 }
 
+export class StudentMonitorException extends Error {
+  constructor() {
+    super();
+    this.message = 'Aluno(a) é monitor(a) da disciplina.';
+  }
+}
+
 export class StudentNotEnrolledException extends Error {
   constructor() {
     super();


### PR DESCRIPTION
# Descrição

[📌 Criar rotas de matricular e desmatricular](https://computero.atlassian.net/browse/DS-271)


Faz as seguintes correções nas rotas de matrícula
- Retorna 404 se for passado o ID de uma disciplina inexistente nas rotas de matrícula e desmatrícula
- Retorna 412 se o aluno tentar se matricular em uma disciplina em que tem monitoria aberta (status aguardando aprovação, disponível ou aprovada)

# Setup

- [ ] `make up`
- [ ] Faça login com a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`

# Cenários

## 1. Erro 404

- [ ] Faça uma requisição para a rota `POST /subject/24524542/enroll` e verifique que o retorno 404
- [ ] Faça uma requisição para a rota `DELETE /subject/24524542/enroll` e verifique que o retorno 404

## 2. Erro 4120

- [ ] Faça uma requisição para a rota `POST /subject/2/enroll` e verifique que o retorno 412
