### PR TITLE
feat: Bloquear Coordenador de outro departamento

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { JwtService } from '@nestjs/jwt';
 import { comparePassword } from 'src/utils/bcrypt';
 import { UserService } from '../user/user.service';
 import { LoginDto } from './dto/login.dto';
+import { Role } from './enums/role.enum';
 import { JWTUser } from './interfaces/jwt-user.interface';
 
 @Injectable()
@@ -27,11 +28,19 @@ export class AuthService {
         ? user.student.Monitor[0]
         : undefined;
 
+      let coordinadorDepartment = undefined;
+      if (user.type_user.type == Role.Coordinator) {
+        coordinadorDepartment = (
+          await this.userService.findOneByIdWithDepartment(user.id)
+        ).department;
+      }
+
       return {
         id: user.id,
         username: user.name,
         type_user_id: user.type_user_id,
         type_user: user.type_user,
+        department: coordinadorDepartment,
         monitor,
       };
     }
@@ -46,6 +55,7 @@ export class AuthService {
       type_user: user.type_user,
       type_user_id: user.type_user_id,
       monitor: user.monitor,
+      department: user.department,
     };
     return {
       access_token: this.jwtService.sign(payload),

--- a/src/auth/interfaces/jwt-user.interface.ts
+++ b/src/auth/interfaces/jwt-user.interface.ts
@@ -15,6 +15,12 @@ export interface JWTUser {
     student_id: number;
     subject_id: number;
   };
+  department?: {
+    id: number;
+    code: string;
+    name: string;
+    abbreviation: string;
+  };
   type_user_id: number;
   iat?: number;
   exp?: number;

--- a/src/subject/commands/end-responsability-command.ts
+++ b/src/subject/commands/end-responsability-command.ts
@@ -6,20 +6,32 @@ import {
   BlockingMonitorsException,
   ResponsabilityNotFoundException,
 } from '../utils/exceptions';
+import { CoordinatorIsNotFromDepartment } from 'src/teacher/utils/exceptions';
 import { SubjectResponsabilityStatus } from '../utils/subject.enum';
+import { JWTUserDTO } from 'src/teacher/dto/user-token.dto';
 
 @Injectable()
 export class EndResponsabilityCommand {
   constructor(private prisma: PrismaService) {}
 
-  async execute(responsabilityId: number): Promise<void> {
+  async execute(userData: JWTUserDTO, responsabilityId: number): Promise<void> {
     const AMT_OFFSET_IN_MS = -4 * 60 * 60 * 1000;
     const now = new Date();
     const nowAMT = new Date(now.getTime() + AMT_OFFSET_IN_MS).toISOString();
 
     const responsability = await this.prisma.subjectResponsability.findUnique({
       where: { id: responsabilityId },
+      include: {
+        subject: true,
+      },
     });
+
+    if (
+      userData.department == undefined ||
+      userData.department.id != responsability.subject.department_id
+    ) {
+      throw new CoordinatorIsNotFromDepartment();
+    }
 
     if (!responsability) {
       throw new ResponsabilityNotFoundException();

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  UnauthorizedException,
   Controller,
   Delete,
   Get,
@@ -36,6 +37,7 @@ import {
   SubjectNotFoundException,
   UserNotStudentException,
 } from './utils/exceptions';
+import { CoordinatorIsNotFromDepartment } from 'src/teacher/utils/exceptions';
 
 import { CancelSubjectEnrollmentCommand } from './commands/cancel-subject-enrollment.command';
 import { CreateSubjectEnrollmentCommand } from './commands/create-subject-enrollment.command';
@@ -94,12 +96,19 @@ export class SubjectController {
     summary: 'Atualiza o status de uma responsabilidade para 3 (finalizada)',
   })
   @Patch('responsability/:id/end')
-  async endResponsability(@Param('id') id: number) {
+  async endResponsability(@Req() req: Request, @Param('id') id: number) {
+    const token = req.headers.authorization.toString().replace('Bearer ', '');
+    const user = this.jwtService.decode(token) as JWTUser;
+
     try {
-      return await this.endResponsabilityCommand.execute(id);
+      return await this.endResponsabilityCommand.execute(user, id);
     } catch (error) {
       if (error instanceof ResponsabilityNotFoundException) {
         throw new NotFoundException(error.message);
+      }
+
+      if (error instanceof CoordinatorIsNotFromDepartment) {
+        throw new UnauthorizedException(error.message);
       }
 
       if (

--- a/src/teacher/dto/user-token.dto.ts
+++ b/src/teacher/dto/user-token.dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from 'src/auth/enums/role.enum';
+
+export class UserTypeDTO {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  type: Role;
+}
+
+export class MonitorDTO {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  id_status: number;
+
+  @ApiProperty()
+  end_date: Date;
+
+  @ApiProperty()
+  responsible_professor_id: number;
+
+  @ApiProperty()
+  student_id: number;
+
+  @ApiProperty()
+  subject_id: number;
+}
+
+export class DepartmentDTO {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  code: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  abbreviation: string;
+}
+
+export class JWTUserDTO {
+  @ApiProperty()
+  sub: number;
+
+  @ApiProperty()
+  username: string;
+
+  @ApiProperty()
+  type_user: UserTypeDTO;
+
+  @ApiProperty({ required: false })
+  monitor?: MonitorDTO;
+
+  @ApiProperty({ required: false })
+  department?: DepartmentDTO;
+
+  @ApiProperty()
+  type_user_id: number;
+
+  @ApiProperty({ required: false })
+  iat?: number;
+
+  @ApiProperty({ required: false })
+  exp?: number;
+}

--- a/src/teacher/teacher.controller.ts
+++ b/src/teacher/teacher.controller.ts
@@ -1,6 +1,8 @@
 import {
   Body,
   ConflictException,
+  ForbiddenException,
+  UnauthorizedException,
   Controller,
   Get,
   HttpStatus,
@@ -8,6 +10,7 @@ import {
   NotFoundException,
   Param,
   Post,
+  Req,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -17,8 +20,11 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { ParamIdDto } from 'src/common/dto/param-id.dto';
+import { JWTUser } from 'src/auth/interfaces/jwt-user.interface';
 import { QueryPaginationDto } from 'src/common/dto/query-pagination.dto';
 import { IResponsePaginate } from 'src/common/interfaces/pagination.interface';
 import { ListTeacherSubjectsCommand } from './commands/list-teacher-subjects.command';
@@ -27,6 +33,8 @@ import { TeacherAssingDto } from './dto/teacher-assing.dto';
 import { TeacherService } from './teacher.service';
 import {
   TeacherAlreadyResponsibleException,
+  CoordinatorIsNotFromDepartment,
+  UserNotCoordinatorException,
   TeacherNotFoundException,
 } from './utils/exceptions';
 import { AssignSubjectCommand } from './commands/assign-subject.command';
@@ -41,6 +49,7 @@ export class TeacherController {
     private readonly teacherService: TeacherService,
     private readonly listTeacherSubjectsCommand: ListTeacherSubjectsCommand,
     private readonly assignSubjectCommand: AssignSubjectCommand,
+    private jwtService: JwtService,
   ) {}
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
@@ -75,15 +84,26 @@ export class TeacherController {
     description: 'Token inválido.',
   })
   @Post('assign-subject')
-  async assignSubject(@Body() body: TeacherAssingDto) {
+  async assignSubject(@Req() req: Request, @Body() body: TeacherAssingDto) {
+    const token = req.headers.authorization.toString().replace('Bearer ', '');
+    const user = this.jwtService.decode(token) as JWTUser;
+
     try {
-      return await this.assignSubjectCommand.execute(body);
+      return await this.assignSubjectCommand.execute(user, body);
     } catch (error) {
       if (
         error instanceof SubjectNotFoundException ||
         error instanceof TeacherNotFoundException
       ) {
         throw new NotFoundException(error.message);
+      }
+
+      if (error instanceof UserNotCoordinatorException) {
+        throw new ForbiddenException(error.message);
+      }
+
+      if (error instanceof CoordinatorIsNotFromDepartment) {
+        throw new UnauthorizedException(error.message);
       }
 
       if (error instanceof TeacherAlreadyResponsibleException) {

--- a/src/teacher/teacher.module.ts
+++ b/src/teacher/teacher.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { JwtModule, JwtService } from '@nestjs/jwt';
 import { TeacherService } from './teacher.service';
 import { PrismaService } from 'src/database/prisma.service';
 import { TeacherController } from './teacher.controller';
@@ -17,9 +18,10 @@ import { EmailService } from 'src/email/email.service';
     EmailService,
     ListTeacherSubjectsCommand,
     AssignSubjectCommand,
+    JwtService,
   ],
   exports: [TeacherService],
-  imports: [SubjectModule, EmailModule],
+  imports: [SubjectModule, EmailModule, JwtModule],
   controllers: [TeacherController],
 })
 export class TeacherModule {}

--- a/src/teacher/utils/exceptions.ts
+++ b/src/teacher/utils/exceptions.ts
@@ -11,3 +11,17 @@ export class TeacherAlreadyResponsibleException extends Error {
     this.message = 'Professor(a) já responsável pela matéria.';
   }
 }
+
+export class UserNotCoordinatorException extends Error {
+  constructor() {
+    super();
+    this.message = 'Usuário(a) logado(a) não é Coordenador(a).';
+  }
+}
+
+export class CoordinatorIsNotFromDepartment extends Error {
+  constructor() {
+    super();
+    this.message = 'Coordenador(a) não pertence ao Departamento da Disciplina.';
+  }
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -223,6 +223,15 @@ export class UserService {
     });
   }
 
+  async findOneByIdWithDepartment(id: number) {
+    return this.prisma.coordinators.findFirst({
+      where: { id },
+      include: {
+        department: true,
+      },
+    });
+  }
+
   async findOneByEmail(email: string) {
     return this.prisma.user.findUnique({
       where: { email },


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Ajustar permissões de coordenadores](https://computero.atlassian.net/browse/DS-285)


<!-- O que este pull request faz? -->
Comentário resumido sobre o objetivo do Pull Request
- As rotas a seguir foram bloqueadas para, caso um coordenador esteja logado, somente consiga realizar alterações se pertencer ao mesmo departamento da Disciplina em questão.
- Rotas Bloqueadas:
`POST /teacher/assign-subject`
`PATCH /subject/responsability/{id}/end`
`PATCH /monitor/{id}/refuse`
`PATCH /monitor/{id}/accept`
`PATCH /monitor/{monitorId}/end`

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `coordenador@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Diretamente no Banco de Dados, alterar o ID do Departamento do Coordenador Passito para `1` (Somente para fins de Teste)
- [ ] Tentar realizar requisições para as rotas: 
`POST /teacher/assign-subject`
`PATCH /subject/responsability/{id}/end`
`PATCH /monitor/{id}/refuse`
`PATCH /monitor/{id}/accept`
`PATCH /monitor/{monitorId}/end`
- [ ] Verificar que não será possível completar as requisições.
**Código HTTP**: 401 - UNAUTHORIZED
**Menssagem de Erro**: Coordenador(a) não pertence ao Departamento da Disciplina.
