### PR TITLE
Concerta parametros com warn do docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
         ports: 
             - $HTTP_REPLICA_PORTS:$HTTP_PORT
         command: npm run start:prod
-        scale: $API_REPLICAS
+        deploy:
+            replicas: $API_REPLICAS
 
 volumes:
     mysql_prod:


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Consertar erro do parametro replicas ](https://computero.atlassian.net/browse/DS-243?atlOrigin=eyJpIjoiNmIxZTcyNDZmOTRlNGY2ZjlmYTQ2ZDVhNWNlZjcwNTEiLCJwIjoiaiJ9)

<!-- O que este pull request faz? -->
Altera o parametro replicas de instancias no docker-compose do backend. 

### 🐞 Em casos de bugfix
- Qual foi a causa do bug?
 Ao subir a instancia no servidor o docker está lançando um warn de função deprecated.
- O que foi feito para corrigi-lo?
 Alteração no docker-ompose com o novo formato para subir instancia, sugerido pelo docker. 

# Cenários
Ao subir a aplicação, em stagin ou em produção o docker disparava um warn de função deprecated. 
