### PR TITLE
fix: corrige permissao de professor para aceitar/recusar monitor

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -35,6 +35,12 @@ export class AuthService {
         ).department;
       }
 
+      if (user.type_user.type == Role.Professor) {
+        coordinadorDepartment = (
+          await this.userService.findOneTeacherByIdWithDepartment(user.id)
+        ).department;
+      }
+
       return {
         id: user.id,
         username: user.name,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -232,6 +232,15 @@ export class UserService {
     });
   }
 
+  async findOneTeacherByIdWithDepartment(user_id: number) {
+    return this.prisma.teacher.findFirst({
+      where: { user_id },
+      include: {
+        department: true,
+      },
+    });
+  }
+
   async findOneByEmail(email: string) {
     return this.prisma.user.findUnique({
       where: { email },


### PR DESCRIPTION
# Descrição


<!-- O que este pull request faz? -->
Comentário resumido sobre o objetivo do Pull Request

- Adiciona informações de token caso o usuário seja professor.

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
- Usuário do tipo professor não conseguia aceitar/recusar monitores pois as informações de token não estavam sendo coletadas corretamente.

- O que foi feito para corrigi-lo?
Adicionado funções para coletar essas informações.

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `juan.professor@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Recuse a monitoria de id 1, verifique se a recusa foi feita com sucesso.
- [ ] Altere no banco o monitor com id novamente para o status 1 (pendente).
- [ ] Aceite a monitoria de id 1, verifique se a monitoria foi aceita com sucesso.
