### PR TITLE
feat: Criar rota que retorne todas as disciplinas sem nenhum tipo de paginação

### DIFF
--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -80,6 +80,32 @@ export class SubjectController {
 
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiOperation({ description: 'Rota para listar todas as disciplinas sem paginação.' })
+  @Get("/all")
+  async findAllSemPaginacao(
+    @Req() req: Request,
+    @Query() query: SubjectQueryDto,
+  ){
+    const token = req.headers.authorization.toString().replace('Bearer ', '');
+    const user = this.jwtService.decode(token) as JWTUser;
+
+    try {
+      return await this.subjectService.findAllSemPaginacao(
+        user.sub,
+        user.type_user.type,
+        query,
+      );
+    } catch (error) {
+      if (error instanceof UserNotStudentException) {
+        throw new BadRequestException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get(':id')
   async findOne(@Req() req: Request, @Param('id') id: number) {
     const token = req.headers.authorization.toString().replace('Bearer ', '');


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Adiciona uma nova rota que retornar todas as disciplinas sem nenhum tipo de paginação


# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A

- [ ] Acesse a nova rota: "/subject/all"  
- [ ] Faça uma requisição GET
- [ ] Verifique todas as disciplinas na resposta

