### PR TITLE
fix: Remover restrição de Monitoria

### DIFF
--- a/src/monitor/monitor.service.ts
+++ b/src/monitor/monitor.service.ts
@@ -71,21 +71,6 @@ export class MonitorService {
     if (!professor)
       throw new NotFoundException('Professor(a) não encontrado(a).');
 
-    const hasMonitoring = await this.prismaService.monitor.findFirst({
-      where: {
-        student_id: user_id,
-        id_status: {
-          in: [1, 2, 3],
-        },
-      },
-      include: { status: true },
-    });
-
-    if (hasMonitoring)
-      throw new BadRequestException(
-        `Você já possui uma monitoria com o status: ${hasMonitoring.status.status}`,
-      );
-
     const email: string = professor.email;
     const sub = 'Você recebeu uma nova solicitação!';
     const context = { student_name: user.name, subject_name: subject.name };


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Remover restrição de Monitoria](https://computero.atlassian.net/browse/DS-313)


<!-- O que este pull request faz? -->
- Remover restrição de monitoria onde um aluno só pode ser monitor de apenas uma disciplina por vez no sistema

# Setup

<!-- Exemplo de setup -->
- [ ] Altere o arquivo `.env` para rodar localmente apontando para o banco de staging (AWS).
- [ ] Suba a API com `make up`
- [ ] Faça login com a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Acessar /monitor/request
- [ ] Fazer uma nova requisição para um monitor com uma monitoria em outra disciplina no sistema